### PR TITLE
Bump styleguide version to fix is-selected bug for errored radio

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem "administrate-field-enum"
 gem "attr_encrypted"
 gem "aws-sdk-s3", require: false
 gem "bootsnap", ">= 1.1.0", require: false
-gem "cfa-styleguide", git: "https://github.com/codeforamerica/cfa-styleguide-gem"
+gem "cfa-styleguide", git: "https://github.com/codeforamerica/cfa-styleguide-gem", ref: "7912b59"
 gem "combine_pdf"
 gem "devise"
 gem "devise-otp",

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,9 @@
 GIT
   remote: https://github.com/codeforamerica/cfa-styleguide-gem
-  revision: 8b61aaca6f4d332b8382f53804ad01f1ac25e402
+  revision: 7912b5988af97125ec2d6d98a0f8382d366f407e
+  ref: 7912b59
   specs:
-    cfa-styleguide (0.3.0)
+    cfa-styleguide (0.3.1)
       autoprefixer-rails
       bourbon
       jquery-rails


### PR DESCRIPTION
We had this fixed in Michigan (with seemingly backwards-compatible changes), so pulled that over into the styleguide.

Here's the relevant PR to the styleguide repo, with a version bump. Got the okay from CMR on the PR, too: https://github.com/codeforamerica/cfa-styleguide-gem/pull/7

![screen shot 2018-10-03 at 12 13 17 pm](https://user-images.githubusercontent.com/3675092/46433452-bd549100-c705-11e8-9956-da08a4c1878e.png)

[Fixes #160807416]