### PR TITLE
Make the generated pdf fields smaller so everything fits on one page

### DIFF
--- a/app/assets/stylesheets/pdf.scss
+++ b/app/assets/stylesheets/pdf.scss
@@ -1,7 +1,7 @@
 .pdf {
-  font-size: 1.9rem;
+  font-size: 1.3rem;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
-  line-height: 1.5em;
+  line-height: 1.1em;
 
   .divider {
     margin-top: 40px;
@@ -20,8 +20,8 @@
   }
 
   h1 {
-    font-size: 3.6rem;
-    line-height: 1.3em;
+    font-size: 2.3rem;
+    line-height: 1em;
     font-weight: 800;
   }
 
@@ -31,22 +31,22 @@
 
   .column {
     display: inline-block;
-    margin-right: 40px;
+    margin-right: 30px;
 
     &.one-of-one {
-      width: 96%;
+      width: 89%;
     }
 
     &.one-of-two {
-      width: 47%;
+      width: 40%;
     }
 
     &.one-of-four {
-      width: 23%;
+      width: 20%;
     }
 
     &.three-of-four {
-      width: 71%;
+      width: 65%;
     }
   }
 

--- a/spec/features/admin/admin_dashboard_spec.rb
+++ b/spec/features/admin/admin_dashboard_spec.rb
@@ -40,15 +40,15 @@ RSpec.feature "Admin viewing dashboard" do
       click_on "Download"
 
       pdf = PDF::Reader.new(StringIO.new(page.html))
-      pdf_text = pdf.pages.map do |page|
-        page.text.gsub("\t", " ").gsub("\n", " ").squeeze(" ")
-      end.join(" ")
+      pdf_text = pdf.pages.first.text.gsub("\t", " ").gsub("\n", " ").squeeze(" ")
+      pdf_attachment_text = pdf.pages.last.text
 
       expect(pdf_text).to have_content "Change Request Form"
       expect(pdf_text).to have_content "Todd Chavez"
       expect(pdf_text).to have_content "See attached"
-      expect(pdf_text).to have_content "This is the test pdf contents."
       expect(pdf_text).to_not have_content "Supervisor or manager's name"
+
+      expect(pdf_attachment_text).to have_content "This is the test pdf contents."
     end
   end
 
@@ -65,9 +65,7 @@ RSpec.feature "Admin viewing dashboard" do
       click_on "Download"
 
       pdf = PDF::Reader.new(StringIO.new(page.html))
-      pdf_text = pdf.pages.map do |page|
-        page.text.gsub("\t", " ").gsub("\n", " ").squeeze(" ")
-      end.join(" ")
+      pdf_text = pdf.pages.first.text.gsub("\t", " ").gsub("\n", " ").squeeze(" ")
 
       expect(pdf_text).to have_content "Client does not have this"
       expect(pdf_text).to have_content "Supervisor or manager's name"


### PR DESCRIPTION
It looked different locally than on heroku. This should look right on staging now.

[#160521773]