### PR TITLE
Move SSN warning inbetween label and field

### DIFF
--- a/app/helpers/cfa_form_builder.rb
+++ b/app/helpers/cfa_form_builder.rb
@@ -33,7 +33,8 @@ class CfaFormBuilder < ActionView::Helpers::FormBuilder
     classes: [],
     prefix: nil,
     autofocus: nil,
-    optional: false
+    optional: false,
+    notice: nil
   )
     classes = classes.append(%w[text-input])
 
@@ -56,6 +57,7 @@ class CfaFormBuilder < ActionView::Helpers::FormBuilder
       prefix: prefix,
       optional: optional,
       options: options,
+      notice: notice
     )
 
     html_output = <<~HTML
@@ -264,7 +266,8 @@ class CfaFormBuilder < ActionView::Helpers::FormBuilder
     help_text: nil,
     prefix: nil,
     optional: false,
-    options: {}
+    options: {},
+    notice: nil
   )
     if options[:input_id]
       for_options = options.merge(
@@ -279,13 +282,15 @@ class CfaFormBuilder < ActionView::Helpers::FormBuilder
       label_contents(label_text, help_text, optional),
       (for_options || options),
     )
+    formatted_label += notice_html(notice).html_safe if notice
+
     if prefix
       <<~HTML
         #{formatted_label}
-                <div class="text-input-group">
-                  <div class="text-input-group__prefix">#{prefix}</div>
-                  #{field}
-                </div>
+        <div class="text-input-group">
+          <div class="text-input-group__prefix">#{prefix}</div>
+          #{field}
+        </div>
       HTML
     else
       formatted_label + field
@@ -302,6 +307,19 @@ class CfaFormBuilder < ActionView::Helpers::FormBuilder
         </span>
       HTML
     end
+  end
+
+  def notice_html(notice_text)
+    <<~HTML
+      <div class="notice grid">
+        <div class="grid__item width-one-twelfth">
+          <i class="illustration illustration--safety"></i>
+        </div>
+        <div class="grid__item width-five-sixths">
+          #{notice_text}
+        </div>
+      </div>
+    HTML
   end
 
   def error_state(object, method)

--- a/app/helpers/cfa_form_builder.rb
+++ b/app/helpers/cfa_form_builder.rb
@@ -57,7 +57,7 @@ class CfaFormBuilder < ActionView::Helpers::FormBuilder
       prefix: prefix,
       optional: optional,
       options: options,
-      notice: notice
+      notice: notice,
     )
 
     html_output = <<~HTML

--- a/app/views/tell_us_about_yourself/edit.html.erb
+++ b/app/views/tell_us_about_yourself/edit.html.erb
@@ -9,20 +9,11 @@
                           "What is your case number?",
                           help_text: "You can find this on letters that the county has sent you.",
                           optional: true %>
-    <div class="notice grid">
-      <div class="grid__item width-one-twelfth">
-        <i class="illustration illustration--safety"></i>
-      </div>
-      <div class="grid__item width-five-sixths">
-        <p>
-          If you don't have an SSN or don't want to give one now it's okay to skip this. But if you add it now, the application process may go faster.
-        </p>
-      </div>
-    </div>
     <%= f.cfa_input_field :ssn,
                           "What is your social security number?",
                           classes: ["form-width--ssn"],
-                          optional: true %>
+                          optional: true,
+                          notice: "If you don't have an SSN or don't want to give one now it's okay to skip this. But if you add it now, the application process may go faster." %>
     <%= f.cfa_input_field :phone_number, "What is your phone number?", classes: ["form-width--phone"] %>
   <% end %>
 <% end %>


### PR DESCRIPTION
Also adds a notice_html helper and option to formbuilder.

![screen shot 2018-10-03 at 3 49 43 pm](https://user-images.githubusercontent.com/3675092/46443817-fd2a7100-c723-11e8-941d-ddd4491ec713.png)
![screen shot 2018-10-03 at 3 49 31 pm](https://user-images.githubusercontent.com/3675092/46443818-fd2a7100-c723-11e8-8dc2-ce1e66ef6fd9.png)

[Fixes #160903182]