### PR TITLE
Disable start until launch

### DIFF
--- a/app/lib/gate_keeper.rb
+++ b/app/lib/gate_keeper.rb
@@ -2,4 +2,8 @@ class GateKeeper
   def self.demo_environment?
     ENV["DEMO_MODE"] == "true"
   end
+
+  def self.feature_enabled?(feature)
+    ENV["#{feature}_ENABLED"] == "true"
+  end
 end

--- a/app/views/static_pages/index.html.erb
+++ b/app/views/static_pages/index.html.erb
@@ -6,11 +6,16 @@
       Report job changes to your Food Assistance (Food Stamps) case
     </h1>
 
-    <%= link_to screen_path(FormNavigation.first) do %>
-      <button class="button button--large button--cta">Start my report <i class="button__icon icon-arrow_forward"></i></button>
+    <% if GateKeeper.feature_enabled?("PRE_LAUNCH") %>
+      <button class="button button--large button--cta" disabled>Start my report <i class="button__icon icon-arrow_forward"></i></button>
+      <p>Coming soon — check back!</p>
+    <% else %>
+      <%= link_to screen_path(FormNavigation.first) do %>
+        <button class="button button--large button--cta">Start my report <i class="button__icon icon-arrow_forward"></i></button>
+      <% end %>
+      <p>It only takes 10 minutes</p>
     <% end %>
 
-    <p>It only takes 10 minutes</p>
   </div>
 </section>
 
@@ -22,7 +27,10 @@
         If your income rises by a certain amount you need to report the change to your Food Assistance case. If your income falls, you may be eligible for more benefits.
       </p>
       <p class="h3">
-        <%= link_to 'Start your report', screen_path(FormNavigation.first) %> now. We’ll guide you through the process with simple step-by-step directions.
+        <% unless GateKeeper.feature_enabled?("PRE_LAUNCH") %>
+          <%= link_to 'Start your report', screen_path(FormNavigation.first) %> now.
+        <% end %>
+        We’ll guide you through the process with simple step-by-step directions.
       </p>
     </div>
     <div class="grid__item width-one-fourth shift-one-sixth trust-badge">

--- a/spec/features/site_launch_spec.rb
+++ b/spec/features/site_launch_spec.rb
@@ -1,0 +1,16 @@
+require "rails_helper"
+
+RSpec.feature "Pre-launch" do
+  around do |example|
+    with_modified_env PRE_LAUNCH_ENABLED: "true" do
+      example.run
+    end
+  end
+
+  scenario "applying" do
+    visit "/"
+    expect(page).to have_text "Coming soon"
+    expect(page).to have_button("Start my report", disabled: true)
+    expect(page).not_to have_link("Start my report")
+  end
+end

--- a/spec/lib/gate_keeper_spec.rb
+++ b/spec/lib/gate_keeper_spec.rb
@@ -16,4 +16,20 @@ describe GateKeeper do
       end
     end
   end
+
+  describe ".feature_enabled?" do
+    context "when environment variable is set" do
+      it "returns true" do
+        with_modified_env BEST_THING_ENABLED: "true" do
+          expect(GateKeeper.feature_enabled?("BEST_THING")).to eq(true)
+        end
+      end
+    end
+
+    context "when environment variable is not set" do
+      it "returns false" do
+        expect(GateKeeper.feature_enabled?("BEST_THING")).to eq(false)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Requested by Sarah in response to the demo site.

We don't want people to accidentally apply before we go live, so this commit makes that more difficult.

Disable links by setting PRE_LAUNCH_ENABLED to true.

[Finishes #161100865]