### PR TITLE
Block /screens in production

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,7 @@ Rails.application.routes.draw do
 
   root "static_pages#index"
 
-  resources :screens, controller: :forms, only: %i[index show] do
+  resources :screens, controller: :forms, only: (Rails.env.production? ? %i[show] : %i[show index]) do
     collection do
       FormNavigation.form_controllers.each do |controller_class|
         { get: :edit, put: :update }.each do |method, action|

--- a/spec/routing/form_navigation_routing_spec.rb
+++ b/spec/routing/form_navigation_routing_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+RSpec.describe "form navigation routing" do
+  context "in production" do
+    before do
+      allow(Rails).to receive(:env) { "production".inquiry }
+      Rails.application.reload_routes!
+    end
+
+    after do
+      allow(Rails).to receive(:env).and_call_original
+      Rails.application.reload_routes!
+    end
+
+    it "blocks access to screens index" do
+      expect(get: "/screens").not_to be_routable
+    end
+  end
+
+  context "outside of production" do
+    it "grants access to screens index" do
+      expect(get: "/screens").to be_routable
+    end
+  end
+end


### PR DESCRIPTION
We want to prevent people from accidentally hopping around the application in production, so we're blocking the index.

For now, it's blocked entirely.

[Finishes #161069387]