### PR TITLE
Add Change Type screen

### DIFF
--- a/app/controllers/add_letter_controller.rb
+++ b/app/controllers/add_letter_controller.rb
@@ -1,5 +1,9 @@
 class AddLetterController < FormsController
   def self.show_rule_sets(change_report)
-    super << change_report.navigator.has_letter_yes?
+    rules = [
+      change_report.navigator.has_letter_yes?,
+      change_report.change_type_job_termination?,
+    ]
+    super + rules
   end
 end

--- a/app/controllers/change_type_controller.rb
+++ b/app/controllers/change_type_controller.rb
@@ -1,0 +1,5 @@
+class ChangeTypeController < FormsController
+  def self.show_rule_sets(_change_report)
+    super << GateKeeper.feature_enabled?("NEW_JOB_FLOW")
+  end
+end

--- a/app/controllers/do_you_have_a_letter_controller.rb
+++ b/app/controllers/do_you_have_a_letter_controller.rb
@@ -1,1 +1,5 @@
-class DoYouHaveALetterController < FormsController; end
+class DoYouHaveALetterController < FormsController
+  def self.show_rule_sets(change_report)
+    super << change_report.change_type_job_termination?
+  end
+end

--- a/app/controllers/proof_info_controller.rb
+++ b/app/controllers/proof_info_controller.rb
@@ -1,4 +1,8 @@
 class ProofInfoController < FormsController
+  def self.show_rule_sets(change_report)
+    super << change_report.change_type_job_termination?
+  end
+
   def form_class
     NullForm
   end

--- a/app/controllers/tell_us_about_the_job_controller.rb
+++ b/app/controllers/tell_us_about_the_job_controller.rb
@@ -1,1 +1,5 @@
-class TellUsAboutTheJobController < FormsController; end
+class TellUsAboutTheJobController < FormsController
+  def self.show_rule_sets(change_report)
+    super << change_report.change_type_job_termination?
+  end
+end

--- a/app/controllers/tell_us_about_yourself_controller.rb
+++ b/app/controllers/tell_us_about_yourself_controller.rb
@@ -1,1 +1,5 @@
-class TellUsAboutYourselfController < FormsController; end
+class TellUsAboutYourselfController < FormsController
+  def self.show_rule_sets(change_report)
+    super << change_report.change_type_job_termination?
+  end
+end

--- a/app/forms/change_type_form.rb
+++ b/app/forms/change_type_form.rb
@@ -1,0 +1,9 @@
+class ChangeTypeForm < Form
+  set_attributes_for :change_report, :change_type
+
+  validates_presence_of :change_type, message: "Please pick a change type."
+
+  def save
+    change_report.update(attributes_for(:change_report))
+  end
+end

--- a/app/forms/county_location_form.rb
+++ b/app/forms/county_location_form.rb
@@ -7,6 +7,9 @@ class CountyLocationForm < Form
   def save
     unless change_report.present?
       self.change_report = ChangeReport.create
+
+      while_feature_flag_set_default_type
+
       change_report.create_navigator
     end
 
@@ -18,6 +21,14 @@ class CountyLocationForm < Form
       HashWithIndifferentAccess.new(change_report.navigator.attributes)
     else
       {}
+    end
+  end
+
+  private
+
+  def while_feature_flag_set_default_type
+    unless GateKeeper.feature_enabled?("NEW_JOB_FLOW")
+      change_report.update(change_type: :job_termination)
     end
   end
 end

--- a/app/forms/form_navigation.rb
+++ b/app/forms/form_navigation.rb
@@ -6,6 +6,7 @@ class FormNavigation
     WhereDoYouLiveController,
     SupportedCountyController,
     NotYetSupportedCountyController,
+    ChangeTypeController,
     TellUsAboutYourselfController,
     TellUsAboutTheJobController,
     ProofInfoController,

--- a/app/models/change_report.rb
+++ b/app/models/change_report.rb
@@ -13,6 +13,8 @@ class ChangeReport < ActiveRecord::Base
 
   enum consent_to_sms: { unfilled: 0, yes: 1, no: 2 }, _prefix: :consented_to_sms
   enum feedback_rating: { unfilled: 0, positive: 1, negative: 2, neutral: 3 }, _prefix: :feedback_rating
+  enum change_type: { unfilled: 0, job_termination: 1, new_job: 2 },
+       _prefix: :change_type
 
   scope :signed, -> { where.not(signature: nil) }
 

--- a/app/views/change_type/edit.html.erb
+++ b/app/views/change_type/edit.html.erb
@@ -1,0 +1,15 @@
+<% content_for :form_card_title, "What changed?" %>
+
+<% content_for :form_card_body do %>
+    <%= fields_for(:form, @form, builder: CfaFormBuilder) do |f| %>
+        <%= f.cfa_radio_set :change_type,
+                            label_text: "What changed?",
+                            legend_class: "sr-only",
+                            collection: [
+                              { value: :job_termination, label: "My job ended or I stopped working" },
+                              { value: :new_job, label: "I started a new job" },
+                            ] %>
+    <% end %>
+<% end %>
+
+<% content_for :progress_indicator_percentage, "27" %>

--- a/db/migrate/20181011153217_add_change_type_to_change_report.rb
+++ b/db/migrate/20181011153217_add_change_type_to_change_report.rb
@@ -1,0 +1,6 @@
+class AddChangeTypeToChangeReport < ActiveRecord::Migration[5.2]
+  def change
+    add_column :change_reports, :change_type, :integer
+    change_column_default :change_reports, :change_type, from: nil, to: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_10_10_195032) do
+ActiveRecord::Schema.define(version: 2018_10_11_153217) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -81,6 +81,7 @@ ActiveRecord::Schema.define(version: 2018_10_10_195032) do
 
   create_table "change_reports", force: :cascade do |t|
     t.string "case_number"
+    t.integer "change_type", default: 0
     t.string "company_name"
     t.integer "consent_to_sms", default: 0
     t.datetime "created_at", null: false

--- a/lib/generators/screen/templates/form_controller.template
+++ b/lib/generators/screen/templates/form_controller.template
@@ -6,13 +6,4 @@ class <%= model.camelcase %>Controller < FormsController
   # def self.show_rule_sets(change_report)
   #   super << ShowRules.must_have_supported_county(change_report)
   # end
-
-  private
-
-  <%- if options.doc? -%>
-  # Assign any existing attributes, for showing previously submitted information:
-  <%- end -%>
-  def existing_attributes
-    {}
-  end
 end

--- a/lib/generators/screen/templates/form_model_spec.template
+++ b/lib/generators/screen/templates/form_model_spec.template
@@ -5,6 +5,7 @@ RSpec.describe <%= model.camelcase %>Form do
     context "when some_attribute is provided" do
       it "is valid" do
         form = <%= "#{model.camelcase}Form".classify %>.new(
+          nil,
           some_attribute: "best attribute",
         )
 
@@ -15,6 +16,7 @@ RSpec.describe <%= model.camelcase %>Form do
     context "when some_attribute is not provided" do
       it "is invalid" do
         form = <%= "#{model.camelcase}Form".classify %>.new(
+          nil,
           some_attribute: nil,
         )
 
@@ -34,7 +36,7 @@ RSpec.describe <%= model.camelcase %>Form do
     end
 
     it "persists the values to the correct models" do
-      form = <%= "#{model.camelcase}Form".classify %>.new(valid_params)
+      form = <%= "#{model.camelcase}Form".classify %>.new(change_report, valid_params)
       form.valid?
       form.save
 

--- a/lib/tasks/one_offs.rake
+++ b/lib/tasks/one_offs.rake
@@ -2,5 +2,6 @@
 namespace :one_offs do
   desc "runs all one_offs, remove things from here after they are deployed"
   task run_all: :environment do
+    ChangeReport.where(change_type: nil).update_all(change_type: "job_termination")
   end
 end

--- a/spec/controllers/add_letter_controller_spec.rb
+++ b/spec/controllers/add_letter_controller_spec.rb
@@ -44,20 +44,30 @@ RSpec.describe AddLetterController do
   end
 
   describe "show?" do
-    context "when client has their letter" do
+    context "when client has their letter and lost a job" do
       it "returns true" do
         navigator = build(:change_report_navigator, has_letter: "yes")
-        change_report = create(:change_report, navigator: navigator)
+        change_report = create(:change_report, navigator: navigator, change_type: :job_termination)
 
         show_form = AddLetterController.show?(change_report)
         expect(show_form).to eq(true)
       end
     end
 
-    context "when client does not have letter" do
+    context "when client does not have letter and lost a job" do
       it "returns false" do
         navigator = build(:change_report_navigator, has_letter: "no")
-        change_report = create(:change_report, navigator: navigator)
+        change_report = create(:change_report, navigator: navigator, change_type: :job_termination)
+
+        show_form = AddLetterController.show?(change_report)
+        expect(show_form).to eq(false)
+      end
+    end
+
+    context "when client has a letter but did not lose a job" do
+      it "returns false" do
+        navigator = build(:change_report_navigator, has_letter: "yes")
+        change_report = create(:change_report, navigator: navigator, change_type: :new_job)
 
         show_form = AddLetterController.show?(change_report)
         expect(show_form).to eq(false)

--- a/spec/controllers/change_type_controller_spec.rb
+++ b/spec/controllers/change_type_controller_spec.rb
@@ -1,0 +1,41 @@
+require "rails_helper"
+
+RSpec.describe ChangeTypeController do
+  it_behaves_like "form controller base behavior"
+  it_behaves_like "form controller successful update", {
+    change_type: "job_termination",
+  }
+  it_behaves_like "form controller unsuccessful update"
+
+  describe "show?" do
+    context "when NEW_JOB_FLOW_ENABLED is true" do
+      around do |example|
+        with_modified_env NEW_JOB_FLOW_ENABLED: "true" do
+          example.run
+        end
+      end
+
+      it "returns true" do
+        change_report = create(:change_report, :with_navigator)
+
+        show_form = ChangeTypeController.show?(change_report)
+        expect(show_form).to eq(true)
+      end
+    end
+
+    context "when NEW_JOB_FLOW_ENABLED is false" do
+      around do |example|
+        with_modified_env NEW_JOB_FLOW_ENABLED: "false" do
+          example.run
+        end
+      end
+
+      it "returns false" do
+        change_report = create(:change_report, :with_navigator)
+
+        show_form = ChangeTypeController.show?(change_report)
+        expect(show_form).to eq(false)
+      end
+    end
+  end
+end

--- a/spec/controllers/do_you_have_a_letter_controller_spec.rb
+++ b/spec/controllers/do_you_have_a_letter_controller_spec.rb
@@ -4,5 +4,5 @@ RSpec.describe DoYouHaveALetterController do
   it_behaves_like "form controller base behavior"
   it_behaves_like "form controller successful update", { has_letter: "yes" }
   it_behaves_like "form controller unsuccessful update"
-  it_behaves_like "form controller always shows"
+  it_behaves_like "form controller shows when job termination"
 end

--- a/spec/controllers/proof_info_controller_spec.rb
+++ b/spec/controllers/proof_info_controller_spec.rb
@@ -2,5 +2,5 @@ require "rails_helper"
 
 RSpec.describe ProofInfoController do
   it_behaves_like "form controller base behavior"
-  it_behaves_like "form controller always shows"
+  it_behaves_like "form controller shows when job termination"
 end

--- a/spec/controllers/tell_us_about_the_job_controller_spec.rb
+++ b/spec/controllers/tell_us_about_the_job_controller_spec.rb
@@ -14,5 +14,5 @@ RSpec.describe TellUsAboutTheJobController do
     last_paycheck_year: "2018",
   }
   it_behaves_like "form controller unsuccessful update"
-  it_behaves_like "form controller always shows"
+  it_behaves_like "form controller shows when job termination"
 end

--- a/spec/controllers/tell_us_about_yourself_controller_spec.rb
+++ b/spec/controllers/tell_us_about_yourself_controller_spec.rb
@@ -12,5 +12,5 @@ RSpec.describe TellUsAboutYourselfController do
     birthday_year: "2000",
   }
   it_behaves_like "form controller unsuccessful update"
-  it_behaves_like "form controller always shows"
+  it_behaves_like "form controller shows when job termination"
 end

--- a/spec/features/report_change_not_yet_supported_county_spec.rb
+++ b/spec/features/report_change_not_yet_supported_county_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "Report termination" do
+RSpec.feature "Report change" do
   scenario "county not yet supported" do
     visit "/"
     click_on "Start my report", match: :first

--- a/spec/features/report_new_job_spec.rb
+++ b/spec/features/report_new_job_spec.rb
@@ -1,0 +1,45 @@
+require "rails_helper"
+
+RSpec.feature "Reporting a change" do
+  context "when new job flow is enabled" do
+    around do |example|
+      with_modified_env NEW_JOB_FLOW_ENABLED: "true" do
+        example.run
+      end
+    end
+
+    scenario "new job" do
+      visit "/"
+
+      expect(page).to have_text "Report job changes"
+      click_on "Start my report", match: :first
+
+      expect(page).to have_text "Welcome! Here’s how reporting a change works"
+      click_on "Start the form"
+
+      expect(page).to have_text "do you live in Arapahoe County?"
+      choose "Yes"
+      click_on "Continue"
+
+      expect(page).to have_text "What changed?"
+      choose "I started a new job"
+      click_on "Continue"
+
+      expect(page).to have_text "May we send you text messages"
+      choose "Yes"
+
+      click_on "Continue"
+
+      expect(page).to have_text "Sign your change report"
+      fill_in "Type your full legal name", with: "Person McPeoples"
+      click_on "Sign and submit"
+
+      expect(page).to have_text "You have successfully submitted your change report"
+      choose "Good", allow_label_click: true
+      fill_in "Do you have any feedback for us?", with: "My feedback"
+      click_on "Submit"
+
+      expect(page).to have_content("Thanks for your feedback")
+    end
+  end
+end

--- a/spec/features/report_termination_spec.rb
+++ b/spec/features/report_termination_spec.rb
@@ -77,4 +77,50 @@ RSpec.feature "Reporting a change", js: true do
 
     expect(page).to have_content("Thanks for your feedback")
   end
+
+  context "when new job flow is enabled" do
+    around do |example|
+      with_modified_env NEW_JOB_FLOW_ENABLED: "true" do
+        example.run
+      end
+    end
+
+    scenario "job termination" do
+      visit "/"
+
+      expect(page).to have_text "Report job changes"
+      click_on "Start my report", match: :first
+
+      expect(page).to have_text "Welcome! Here’s how reporting a change works"
+      click_on "Start the form"
+
+      expect(page).to have_text "do you live in Arapahoe County?"
+      choose "I'm not sure"
+      click_on "Continue"
+
+      expect(page).to have_text "Where do you live?"
+
+      fill_in "Street address", with: "1355 South Laredo Court"
+      fill_in "City", with: "Aurora"
+      fill_in "Zip code", with: "80017"
+      click_on "Continue"
+      expect(page).to have_text "Great, it looks like you live in Arapahoe County."
+      click_on "Continue"
+
+      expect(page).to have_text "What changed?"
+      choose "My job ended or I stopped working"
+      click_on "Continue"
+
+      expect(page).to have_text "Tell us about yourself."
+
+      fill_in "What is your name?", with: "Jane Doe"
+      fill_in "What is your phone number?", with: "555-222-3333"
+      select "January", from: "form[birthday_month]"
+      select "1", from: "form[birthday_day]"
+      select 20.years.ago.year.to_s, from: "form[birthday_year]"
+      click_on "Continue"
+
+      expect(page).to have_text "Tell us about the job that ended"
+    end
+  end
 end

--- a/spec/forms/change_type_form_spec.rb
+++ b/spec/forms/change_type_form_spec.rb
@@ -1,0 +1,52 @@
+require "rails_helper"
+
+RSpec.describe ChangeTypeForm do
+  describe "validations" do
+    context "when change_type is provided" do
+      it "is valid" do
+        form = ChangeTypeForm.new(nil, change_type: :job_termination)
+
+        expect(form).to be_valid
+      end
+    end
+
+    context "when change_type is not provided" do
+      it "is invalid" do
+        form = ChangeTypeForm.new(nil, change_type: nil)
+
+        expect(form).not_to be_valid
+        expect(form.errors[:change_type]).to be_present
+      end
+    end
+  end
+
+  describe "#save" do
+    let(:change_report) { create :change_report }
+
+    let(:valid_params) do
+      {
+        change_type: "job_termination",
+      }
+    end
+
+    it "persists the values to the correct models" do
+      form = ChangeTypeForm.new(change_report, valid_params)
+      form.valid?
+      form.save
+
+      change_report.reload
+
+      expect(change_report.change_type_job_termination?).to be_truthy
+    end
+  end
+
+  describe ".from_change_report" do
+    it "assigns values from change report" do
+      change_report = create(:change_report, change_type: "new_job")
+
+      form = ChangeTypeForm.from_change_report(change_report)
+
+      expect(form.change_type).to eq "new_job"
+    end
+  end
+end

--- a/spec/forms/county_location_form_spec.rb
+++ b/spec/forms/county_location_form_spec.rb
@@ -56,6 +56,21 @@ RSpec.describe CountyLocationForm do
         expect(ChangeReport.last.navigator.selected_county_location_arapahoe?).to eq(true)
       end
     end
+
+    context "when the new job feature is disabled" do
+      around do |example|
+        with_modified_env NEW_JOB_FLOW_ENABLED: "false" do
+          example.run
+        end
+      end
+
+      it "sets the change report change type to job_termination" do
+        form = CountyLocationForm.new(nil, valid_params)
+        form.save
+
+        expect(ChangeReport.last.change_type_job_termination?).to be_truthy
+      end
+    end
   end
 
   describe ".from_change_report" do

--- a/spec/support/shared_examples/forms_controller_shows_when_job_termination.rb
+++ b/spec/support/shared_examples/forms_controller_shows_when_job_termination.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+RSpec.shared_examples_for "form controller shows when job termination" do
+  describe "show?" do
+    context "when change_type is job_termination" do
+      it "returns true" do
+        change_report = create(:change_report, change_type: "job_termination")
+
+        show_form = subject.class.show?(change_report)
+        expect(show_form).to eq(true)
+      end
+    end
+
+    context "when change_type is new_job" do
+      it "returns false" do
+        change_report = create(:change_report, change_type: "new_job")
+
+        show_form = subject.class.show?(change_report)
+        expect(show_form).to eq(false)
+      end
+    end
+  end
+end


### PR DESCRIPTION
* only show when feature flag is on
* set default change type of job_termination when feature flag is off
* adds one off rake task to backfill change_type as job_termination

[#160700349]

Signed-off-by: Whitney Schaefer <whitney@codeforamerica.org>
Co-authored-by: Whitney Schaefer <whitney@codeforamerica.org>
Signed-off-by: Andrew Hyder <andrewh@codeforamerica.org>
Co-authored-by: Andrew Hyder <andrewh@codeforamerica.org>