### PR TITLE
Reduce log verbosity

### DIFF
--- a/config/environments/shared_deployment_config.rb
+++ b/config/environments/shared_deployment_config.rb
@@ -28,6 +28,9 @@ Rails.application.configure do
   # Do not fallback to assets pipeline if a precompiled asset is missed.
   config.assets.compile = false
 
+  # Disable logging requests for static assets
+  config.assets.quiet = true
+
   # `config.assets.precompile` and `config.assets.version` have moved to config/initializers/assets.rb
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
@@ -50,7 +53,7 @@ Rails.application.configure do
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
-  config.log_level = :debug
+  config.log_level = :info
 
   # Prepend all log lines with the following tags.
   config.log_tags = [:request_id]


### PR DESCRIPTION
Configures Rails to not log access to static assets, and to use
INFO-level logging by default (this was standard for production before
Rails 5).

Based on tips found here: https://help.papertrailapp.com/kb/configuration/controlling-verbosity#improve-formatting

[Finishes #161435923]