### PR TITLE
Send new job info to Mixpanel

### DIFF
--- a/app/controllers/forms_controller.rb
+++ b/app/controllers/forms_controller.rb
@@ -76,7 +76,7 @@ class FormsController < ApplicationController
     MixpanelService.instance.run(
       unique_id: current_change_report.id,
       event_name: @form.class.analytics_event_name,
-      data: current_change_report.mixpanel_data,
+      data: AnalyticsData.new(current_change_report).to_h,
     )
   end
 
@@ -87,7 +87,7 @@ class FormsController < ApplicationController
     }
 
     if current_change_report.present?
-      data.merge!(current_change_report.try(:mixpanel_data))
+      data.merge!(AnalyticsData.new(current_change_report).to_h)
     end
 
     MixpanelService.instance.run(

--- a/app/models/analytics_data.rb
+++ b/app/models/analytics_data.rb
@@ -1,0 +1,61 @@
+class AnalyticsData
+  def initialize(change_report)
+    @change_report = change_report
+  end
+
+  def to_h
+    hash = change_report_data.merge(navigator_data).merge(member_data)
+    hash.transform_values { |v| unfilled_to_nil(v) }
+  end
+
+  private
+
+  attr_reader :change_report
+
+  def change_report_data
+    {
+      change_type: change_report.change_type,
+      consent_to_sms: change_report.consent_to_sms,
+      days_since_first_day_to_submission: days_since_submission(change_report.first_day),
+      days_since_first_paycheck_to_submission: days_since_submission(change_report.first_paycheck),
+      days_since_last_day_to_submission: days_since_submission(change_report.last_day),
+      days_since_last_paycheck_to_submission: days_since_submission(change_report.last_paycheck),
+      feedback_rating: change_report.feedback_rating,
+      is_self_employed: change_report.is_self_employed,
+      paid_how_often: change_report.paid_how_often,
+      paid_yet: change_report.paid_yet,
+      same_hours: change_report.same_hours,
+      submitted_at: change_report.submitted_at,
+      verification_documents_count: change_report.letters.count,
+    }
+  end
+
+  def navigator_data
+    navigator = change_report.navigator
+    {
+      county_from_address: navigator.try(:county_from_address),
+      has_offer_letter: navigator.try(:has_offer_letter),
+      has_paystub: navigator.try(:has_paystub),
+      has_termination_letter: navigator.try(:has_termination_letter),
+      selected_county_location: navigator.try(:selected_county_location),
+      source: navigator.try(:source),
+    }
+  end
+
+  def member_data
+    member = change_report.member
+    {
+      age: member.try(:age),
+    }
+  end
+
+  def days_since_submission(date)
+    if date && change_report.submitted_at
+      (change_report.submitted_at - date).to_i / 1.day
+    end
+  end
+
+  def unfilled_to_nil(value)
+    value == "unfilled" ? nil : value
+  end
+end

--- a/app/models/change_report.rb
+++ b/app/models/change_report.rb
@@ -35,17 +35,4 @@ class ChangeReport < ActiveRecord::Base
   def image_letters
     letters.select(&:image?)
   end
-
-  def mixpanel_data
-    {
-      selected_county_location: navigator.selected_county_location,
-      county_from_address: navigator.county_from_address,
-      age: member.try(:age),
-      has_termination_letter: navigator.has_termination_letter,
-      letter_count: letters.count,
-      consent_to_sms: consent_to_sms,
-      feedback_rating: feedback_rating,
-      source: navigator.source,
-    }
-  end
 end

--- a/spec/models/analytics_data_spec.rb
+++ b/spec/models/analytics_data_spec.rb
@@ -1,0 +1,92 @@
+require "rails_helper"
+
+RSpec.describe AnalyticsData do
+  let(:mock_change_report) do
+    instance_double(ChangeReport,
+      first_day: nil,
+      first_paycheck: nil,
+      last_day: nil,
+      last_paycheck: nil,
+      letters: [],
+      submitted_at: nil).as_null_object
+  end
+
+  describe "#to_h" do
+    it "returns basic information" do
+      navigator = instance_double(ChangeReportNavigator,
+                                  county_from_address: "Littleland",
+                                  has_offer_letter: "yes",
+                                  has_paystub: "yes",
+                                  has_termination_letter: "yes",
+                                  selected_county_location: "arapahoe",
+                                  source: "Land of Ooo")
+
+      member = instance_double(HouseholdMember, age: 22)
+
+      allow(mock_change_report).to receive_messages(
+        navigator: navigator,
+        member: member,
+        change_type: "new_job",
+        consent_to_sms: "yes",
+        feedback_rating: "positive",
+        is_self_employed: "no",
+        paid_how_often: "monthly",
+        paid_yet: "no",
+        submitted_at: DateTime.new(2018, 1, 2),
+      )
+
+      data = AnalyticsData.new(mock_change_report).to_h
+
+      expect(data.fetch(:age)).to eq(22)
+      expect(data.fetch(:change_type)).to eq("new_job")
+      expect(data.fetch(:consent_to_sms)).to eq("yes")
+      expect(data.fetch(:county_from_address)).to eq("Littleland")
+      expect(data.fetch(:feedback_rating)).to eq("positive")
+      expect(data.fetch(:has_offer_letter)).to eq("yes")
+      expect(data.fetch(:has_paystub)).to eq("yes")
+      expect(data.fetch(:has_termination_letter)).to eq("yes")
+      expect(data.fetch(:is_self_employed)).to eq("no")
+      expect(data.fetch(:paid_how_often)).to eq("monthly")
+      expect(data.fetch(:paid_yet)).to eq("no")
+      expect(data.fetch(:selected_county_location)).to eq("arapahoe")
+      expect(data.fetch(:source)).to eq("Land of Ooo")
+      expect(data.fetch(:verification_documents_count)).to eq(0)
+      expect(data.fetch(:submitted_at)).to eq(DateTime.new(2018, 1, 2))
+    end
+
+    it "calculates time since submission" do
+      submission_date = Time.utc(2018, 1, 10, 1, 2, 3)
+      allow(mock_change_report).to receive_messages(change_type: "new_job",
+                                                    first_day: submission_date - 30.days,
+                                                    first_paycheck: submission_date - 20.days,
+                                                    last_day: submission_date - 90.days,
+                                                    last_paycheck: submission_date - 100.days,
+                                                    same_hours: "yes",
+                                                    submitted_at: submission_date)
+
+      data = AnalyticsData.new(mock_change_report).to_h
+
+      expect(data.fetch(:same_hours)).to eq("yes")
+      expect(data.fetch(:days_since_first_day_to_submission)).to eq(30)
+      expect(data.fetch(:days_since_first_paycheck_to_submission)).to eq(20)
+      expect(data.fetch(:days_since_last_day_to_submission)).to eq(90)
+      expect(data.fetch(:days_since_last_paycheck_to_submission)).to eq(100)
+    end
+
+    it "sends nil for any 'unfilled' values" do
+      allow(mock_change_report).to receive_messages(same_hours: "unfilled")
+
+      data = AnalyticsData.new(mock_change_report).to_h
+
+      expect(data.fetch(:same_hours)).to be_nil
+    end
+
+    context "when member and navigator are not present" do
+      it "does not error" do
+        expect do
+          AnalyticsData.new(build(:change_report)).to_h
+        end.to_not raise_error
+      end
+    end
+  end
+end

--- a/spec/models/change_report_spec.rb
+++ b/spec/models/change_report_spec.rb
@@ -27,31 +27,6 @@ RSpec.describe ChangeReport, type: :model do
     end
   end
 
-  describe "#mixpanel_data" do
-    let(:change_report) do
-      create :change_report,
-             :with_navigator,
-             :with_letter,
-             source: "awesome-cbo",
-             member: create(:household_member, birthday: (30.years.ago - 1.day))
-    end
-
-    it "returns a non-PII representation of change report data" do
-      expect(change_report.mixpanel_data).to eq(
-        {
-          selected_county_location: "unfilled",
-          county_from_address: nil,
-          age: 30,
-          has_termination_letter: "unfilled",
-          letter_count: 1,
-          consent_to_sms: "unfilled",
-          feedback_rating: "unfilled",
-          source: "awesome-cbo",
-        },
-      )
-    end
-  end
-
   describe "#pdf_letters" do
     it "returns all letters that are content_type application/pdf" do
       change_report = create :change_report

--- a/spec/support/shared_examples/forms_controller_successful_update.rb
+++ b/spec/support/shared_examples/forms_controller_successful_update.rb
@@ -24,10 +24,12 @@ RSpec.shared_examples_for "form controller successful update" do |valid_params|
           expect(response).to redirect_to(subject.next_path)
         end
 
-        let(:mock_mixpanel_service) { spy(MixpanelService) }
-
         it "calls the mixpanel service" do
+          mock_mixpanel_service = spy(MixpanelService)
+          fake_analytics_data = { foo: "bar" }
+
           allow(MixpanelService).to receive(:instance).and_return(mock_mixpanel_service)
+          allow(AnalyticsData).to receive(:new).with(current_change_report) { fake_analytics_data }
 
           put :update, params: { form: valid_params }
 
@@ -35,7 +37,7 @@ RSpec.shared_examples_for "form controller successful update" do |valid_params|
           expect(mock_mixpanel_service).to have_received(:run).with(
             unique_id: current_change_report.id,
             event_name: controller.form_class.analytics_event_name,
-            data: current_change_report.mixpanel_data,
+            data: fake_analytics_data,
           )
         end
       end

--- a/spec/support/shared_examples/forms_controller_unsuccessful_update.rb
+++ b/spec/support/shared_examples/forms_controller_unsuccessful_update.rb
@@ -4,11 +4,13 @@ RSpec.shared_examples_for "form controller unsuccessful update" do |invalid_para
   describe "#update" do
     context "on unsucessful update" do
       let(:mock_mixpanel_service) { spy(MixpanelService) }
+      let(:fake_analytics_data) { { foo: "bar" } }
       let(:current_change_report) { create(:change_report, :with_navigator) }
 
       before do
         session[:current_change_report_id] = current_change_report.id
         allow(MixpanelService).to receive(:instance).and_return(mock_mixpanel_service)
+        allow(AnalyticsData).to receive(:new).with(current_change_report) { fake_analytics_data }
 
         put :update, params: { form: invalid_params || {} }
       end
@@ -17,7 +19,7 @@ RSpec.shared_examples_for "form controller unsuccessful update" do |invalid_para
         data = {
           screen: controller.form_class.analytics_event_name,
           errors: assigns(:form).errors.messages.keys,
-        }.merge(current_change_report.mixpanel_data)
+        }.merge(fake_analytics_data)
 
         expect(mock_mixpanel_service).to have_received(:run).with(
           unique_id: current_change_report.id,


### PR DESCRIPTION
Also:
* Refactors AnalyticsData into its own object, from the ChangeReport.
* Adds time between last day and submission for job termination change type
* Don't send "unfilled" to Mixpanel (noisy)

[Finishes #161459618]