### PR TITLE
Add axe-matchers for accessibility testing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,6 +52,7 @@ group :development do
 end
 
 group :test do
+  gem "axe-matchers"
   gem "capybara"
   gem "capybara-selenium"
   gem "chromedriver-helper"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 GIT
   remote: https://github.com/codeforamerica/cfa-styleguide-gem
-  revision: b55da77010737c203f4d05c90ac64f7adc7d54c4
+  revision: dbbb448e25257764b48771c98ab9a92bf0ac0200
   specs:
-    cfa-styleguide (0.4.3)
+    cfa-styleguide (0.4.4)
       autoprefixer-rails
       bourbon
       jquery-rails
@@ -87,7 +87,7 @@ GEM
     ast (2.4.0)
     attr_encrypted (3.1.0)
       encryptor (~> 3.0.0)
-    autoprefixer-rails (9.2.0)
+    autoprefixer-rails (9.3.1)
       execjs
     aws-eventstream (1.0.1)
     aws-partitions (1.105.0)
@@ -104,6 +104,13 @@ GEM
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.0)
     aws-sigv4 (1.0.3)
+    axe-matchers (1.3.4)
+      dumb_delegator (~> 0.8)
+      virtus (~> 1.0)
+    axiom-types (0.1.1)
+      descendants_tracker (~> 0.0.4)
+      ice_nine (~> 0.11.0)
+      thread_safe (~> 0.3, >= 0.3.1)
     bcrypt (3.1.12)
     bindex (0.5.0)
     bootsnap (1.3.2)
@@ -134,6 +141,8 @@ GEM
       nokogiri (~> 1.8)
     climate_control (0.2.0)
     coderay (1.1.2)
+    coercible (1.0.0)
+      descendants_tracker (~> 0.0.1)
     combine_pdf (1.0.15)
       ruby-rc4 (>= 0.1.5)
     concurrent-ruby (1.0.5)
@@ -150,6 +159,8 @@ GEM
       delayed_job (> 2.0.3)
       rack-protection (>= 1.5.5)
       sinatra (>= 1.4.4)
+    descendants_tracker (0.0.4)
+      thread_safe (~> 0.3, >= 0.3.1)
     devise (4.5.0)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -161,7 +172,9 @@ GEM
     dotenv-rails (2.5.0)
       dotenv (= 2.5.0)
       railties (>= 3.2, < 6.0)
+    dumb_delegator (0.8.0)
     encryptor (3.0.0)
+    equalizer (0.0.11)
     erubi (1.7.1)
     execjs (2.7.0)
     factory_bot (4.11.1)
@@ -186,6 +199,7 @@ GEM
     hashie (3.6.0)
     i18n (1.1.1)
       concurrent-ruby (~> 1.0)
+    ice_nine (0.11.2)
     io-like (0.3.0)
     jaro_winkler (1.5.1)
     jbuilder (2.7.0)
@@ -392,6 +406,11 @@ GEM
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
     unicode-display_width (1.4.0)
+    virtus (1.0.5)
+      axiom-types (~> 0.1)
+      coercible (~> 1.0)
+      descendants_tracker (~> 0.0, >= 0.0.3)
+      equalizer (~> 0.0, >= 0.0.9)
     warden (1.2.7)
       rack (>= 1.0)
     web-console (3.7.0)
@@ -415,6 +434,7 @@ DEPENDENCIES
   administrate-field-enum
   attr_encrypted
   aws-sdk-s3
+  axe-matchers
   bootsnap (>= 1.1.0)
   brakeman
   bundler-audit

--- a/app/assets/javascripts/direct_uploads.js
+++ b/app/assets/javascripts/direct_uploads.js
@@ -9,13 +9,15 @@ var directUpload = (function () {
                 });
             };
 
+
             $('input[type=file]').each(function (index, fileInput) {
                 const url = fileInput.dataset.directUploadUrl;
 
-                var uploadBtn = document.getElementById('file-upload');
-                uploadBtn.addEventListener('click', function (e) {
-                    e.preventDefault();
-                    fileInput.click();
+                $('.upload-file-button').each(function (index, uploadFileButton) {
+                    uploadFileButton.addEventListener('click', function (e) {
+                        e.preventDefault();
+                        fileInput.click();
+                    });
                 });
 
                 fileInput.addEventListener('change', function (e) {

--- a/app/assets/javascripts/templates/uploaded_file_detail.hbs
+++ b/app/assets/javascripts/templates/uploaded_file_detail.hbs
@@ -12,7 +12,7 @@
           <div class="doc-preview__thumb emoji emoji--page-facing-up"></div>
         {{else}}
           <div class="doc-preview__thumb">
-              <img src="/rails/active_storage/blobs/{{signedId}}/{{filename}}">
+              <img src="/rails/active_storage/blobs/{{signedId}}/{{filename}}" alt="Preview of uploaded document {{letter.filename}}" >
           </div>
         {{/if}}
     </div>

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -120,3 +120,16 @@
     width: 1.25em;
   }
 }
+
+.input-group--inline .form-group {
+  display: inline-block;
+  margin-bottom: 0;
+}
+
+.range-text {
+  margin: 0 1em;
+}
+
+.form-divider {
+  margin: 1em;
+}

--- a/app/assets/stylesheets/overrides.scss
+++ b/app/assets/stylesheets/overrides.scss
@@ -55,15 +55,8 @@
   margin-top: 1em;
 }
 
-.input-group--inline .form-group {
-  display: inline-block;
-  margin-bottom: 0;
-}
-
-.range-text {
-  margin: 0 1em;
-}
-
-.form-divider {
-  margin: 1em;
+.main-footer {
+  a {
+    color: white;
+  }
 }

--- a/app/views/add_letter/edit.html.erb
+++ b/app/views/add_letter/edit.html.erb
@@ -30,7 +30,7 @@
                 <div class="doc-preview__thumb emoji emoji--page-facing-up"></div>
               <% else %>
                 <div class="doc-preview__thumb">
-                  <%= image_tag url_for(letter), size: "100x100" %>
+                  <%= image_tag url_for(letter), size: "100x100", alt: "Preview of uploaded document #{letter.filename}" %>
                 </div>
               <% end %>
             </div>
@@ -41,8 +41,8 @@
     <div class="text--centered">
       <div class="verification-upload-icon" <% if @form.letters.present? %>style="display: none;"<% end %>></div>
       <div>
-        <button class="button button--cta is-tablet-hidden--inline" id="file-upload">Pick a file from this computer</button>
-        <button class="button button--cta is-desktop-hidden--inline" id="file-upload">Take a picture</button>
+        <button class="button button--cta is-tablet-hidden--inline upload-file-button">Pick a file from this computer</button>
+        <button class="button button--cta is-desktop-hidden--inline upload-file-button">Take a picture</button>
       </div>
     </div>
 <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -3,7 +3,7 @@
   <head>
     <%= render "analytics/ganalytics" %>
 
-    <title>ColoradoBenefits</title>
+    <title>ReportChangesColorado.org</title>
     <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <%= render "analytics/ganalytics" %>
 
     <title>ColoradoBenefits</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 

--- a/app/views/layouts/form.html.erb
+++ b/app/views/layouts/form.html.erb
@@ -11,9 +11,9 @@
     </header>
 
     <div class="slab">
-      <% if content_for? :form_card %>
+        <% if content_for? :form_card %>
           <%= yield :form_card %>
-      <% else %>
+        <% else %>
           <main id="main" class="form-card">
             <%= form_tag @step, as: :step, url: current_path, method: :put %>
             <header class="form-card__header">

--- a/app/views/not_yet_supported/edit.html.erb
+++ b/app/views/not_yet_supported/edit.html.erb
@@ -1,20 +1,20 @@
 <% content_for :form_card do %>
-    <main id="main" class="form-card">
-      <header class="text--centered">
-        <h1 class="form-card__title">Sorry, you'll need to report your change a different way.</h1>
+  <main id="main" class="form-card">
+    <header class="text--centered">
+      <h1 class="form-card__title">Sorry, you'll need to report your change a different way.</h1>
 
-        <p class="text--help">
-          You can submit your change through Colorado PEAK. You can also call or visit your county Department of Human Services office.
-        </p>
-      </header>
+      <p class="text--help">
+        You can submit your change through Colorado PEAK. You can also call or visit your county Department of Human Services office.
+      </p>
+    </header>
 
-      <div class="text--centered">
-        <div class="nudge--med with-padding-small">
-          <%= link_to "Go to PEAK", "https://coloradopeak.secure.force.com/", class: 'button button--full-mobile button--primary' %>
-        </div>
-        <div>
-          <%= link_to "Find my county office", "https://www.colorado.gov/pacific/cdhs/contact-your-county", class: 'button button--full-mobile button--primary' %>
-        </div>
+    <div class="text--centered">
+      <div class="nudge--med with-padding-small">
+        <%= link_to "Go to PEAK", "https://coloradopeak.secure.force.com/", class: 'button button--full-mobile button--primary' %>
       </div>
-    </main>
+      <div>
+        <%= link_to "Find my county office", "https://www.colorado.gov/pacific/cdhs/contact-your-county", class: 'button button--full-mobile button--primary' %>
+      </div>
+    </div>
+  </main>
 <% end %>

--- a/app/views/self_employed/edit.html.erb
+++ b/app/views/self_employed/edit.html.erb
@@ -12,6 +12,8 @@
   </p>
   <%= fields_for(:form, @form, builder: CfaFormBuilder) do |f| %>
   <%= f.cfa_radio_set :is_self_employed,
+    label_text: "Are you self-employed?",
+    legend_class: "sr-only",
     collection: [
       { value: :yes, label: "I am self-employed" },
       { value: :no, label: "I am not self-employed" },

--- a/app/views/static_pages/index.html.erb
+++ b/app/views/static_pages/index.html.erb
@@ -34,7 +34,7 @@
       </p>
     </div>
     <div class="grid__item width-one-fourth shift-one-sixth trust-badge">
-      <%= image_tag("arapahoe.jpg") %>
+      <%= image_tag("arapahoe.jpg", alt: "Arapahoe County seal") %>
       <p class="text--small">In partnership with the Colorado Department of Human Services and Arapahoe County.</p>
     </div>
   </div>

--- a/spec/features/report_new_job_spec.rb
+++ b/spec/features/report_new_job_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "Reporting a change", js: true do
+RSpec.feature "Reporting a change", :a11y, :js do
   include ActiveJob::TestHelper
 
   context "when new job flow is enabled" do
@@ -15,22 +15,22 @@ RSpec.feature "Reporting a change", js: true do
 
     scenario "new job" do
       visit "/"
-      click_on "Start my report", match: :first
+      proceed_with "Start my report", match: :first
 
       expect(page).to have_text "Welcome! Here’s how reporting a change works"
-      click_on "Start the form"
+      proceed_with "Start the form"
 
       expect(page).to have_text "do you live in Arapahoe County?"
       choose "Yes"
-      click_on "Continue"
+      proceed_with "Continue"
 
       expect(page).to have_text "What changed?"
       choose "I started a new job"
-      click_on "Continue"
+      proceed_with "Continue"
 
       expect(page).to have_text "Are you self-employed?"
       choose "I am not self-employed"
-      click_on "Continue"
+      proceed_with "Continue"
 
       expect(page).to have_text "Tell us about yourself."
 
@@ -39,7 +39,7 @@ RSpec.feature "Reporting a change", js: true do
       select "January", from: "form[birthday_month]"
       select "1", from: "form[birthday_day]"
       select 20.years.ago.year.to_s, from: "form[birthday_year]"
-      click_on "Continue"
+      proceed_with "Continue"
 
       expect(page).to have_text "Tell us about the new job."
 
@@ -50,7 +50,7 @@ RSpec.feature "Reporting a change", js: true do
       select "2", from: "form[first_day_day]"
       select "2018", from: "form[first_day_year]"
       choose "Yes"
-      click_on "Continue"
+      proceed_with "Continue"
 
       expect(page).to have_text "Tell us about how much you will make at this job."
 
@@ -62,36 +62,35 @@ RSpec.feature "Reporting a change", js: true do
       select "21", from: "form[first_paycheck_day]"
       select "2018", from: "form[first_paycheck_year]"
       fill_in "Is there anything else we should know about your hours or wages at this job?", with: "Not really"
-      click_on "Continue"
+      proceed_with "Continue"
 
       expect(page).to have_text "Do you have proof of this change?"
       expect(page).to have_text "Paystubs showing your pre-tax earnings"
-      click_on "Continue"
+      proceed_with "Continue"
 
       expect(page).to have_text "What do you have?"
       check "I have an offer letter"
       check "I have paystubs"
-      click_on "Continue"
+      proceed_with "Continue"
 
       expect(page).to have_text "Add your offer letter and paystubs."
 
       page.attach_file("form[letters][]", Rails.root.join("spec", "fixtures", "image.jpg"), make_visible: true)
       expect(page).to have_text "image.jpg"
-      click_on "Continue"
+      proceed_with "Continue"
 
       expect(page).to have_text "May we contact you via text message"
       choose "Yes"
-
-      click_on "Continue"
+      proceed_with "Continue"
 
       expect(page).to have_text "Sign your change report"
       fill_in "Type your full legal name", with: "Person McPeoples"
-      click_on "Sign and submit"
+      proceed_with "Sign and submit"
 
       expect(page).to have_text "You have successfully submitted your change report"
       choose "Good", allow_label_click: true
       fill_in "Do you have any feedback for us?", with: "My feedback"
-      click_on "Submit"
+      proceed_with "Submit"
 
       expect(page).to have_content("Thanks for your feedback")
 

--- a/spec/features/report_termination_spec.rb
+++ b/spec/features/report_termination_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "Reporting a change", js: true do
+feature "Reporting a change", :a11y, :js do
   include ActiveJob::TestHelper
 
   around do |example|
@@ -12,24 +12,25 @@ RSpec.feature "Reporting a change", js: true do
 
   scenario "job termination" do
     visit "/"
-    click_on "Start my report", match: :first
+    expect(page).to have_text "Report the change"
 
+    proceed_with "Start my report", match: :first
     expect(page).to have_text "Welcome! Here’s how reporting a change works"
 
-    click_on "Start the form"
+    proceed_with "Start the form"
     expect(page).to have_text "do you live in Arapahoe County?"
 
     choose "I'm not sure"
-    click_on "Continue"
+    proceed_with "Continue"
 
     expect(page).to have_text "Where do you live?"
 
     fill_in "Street address", with: "1355 South Laredo Court"
     fill_in "City", with: "Aurora"
     fill_in "Zip code", with: "80017"
-    click_on "Continue"
+    proceed_with "Continue"
     expect(page).to have_text "Great, it looks like you live in Arapahoe County."
-    click_on "Continue"
+    proceed_with "Continue"
     expect(page).to have_text "Tell us about yourself."
 
     fill_in "What is your name?", with: "Person McPeoples"
@@ -37,7 +38,7 @@ RSpec.feature "Reporting a change", js: true do
     select "January", from: "form[birthday_month]"
     select "1", from: "form[birthday_day]"
     select 20.years.ago.year.to_s, from: "form[birthday_year]"
-    click_on "Continue"
+    proceed_with "Continue"
 
     expect(page).to have_text "Tell us about the job that ended"
 
@@ -51,38 +52,38 @@ RSpec.feature "Reporting a change", js: true do
     select "12", from: "form[last_paycheck_day]"
     select "2018", from: "form[last_paycheck_year]"
     fill_in "What was the amount of your final paystub, pre-tax?", with: "127.14"
-    click_on "Continue"
+    proceed_with "Continue"
 
     expect(page).to have_text "Do you have proof of this change?"
     expect(page).to have_text "A letter from your old employer"
 
-    click_on "Continue"
+    proceed_with "Continue"
 
     expect(page).to have_text "Do you have a letter or final paycheck?"
 
     choose "Yes"
-    click_on "Continue"
+    proceed_with "Continue"
 
     expect(page).to have_text "Add your letter or final paycheck."
 
     page.attach_file("form[letters][]", Rails.root.join("spec", "fixtures", "image.jpg"), make_visible: true)
     expect(page).to have_text "image.jpg"
-    click_on "Continue"
+    proceed_with "Continue"
 
     expect(page).to have_text "May we contact you via text message"
     expect(page).to have_text "We'll send text messages to (555) 222-3333"
     choose "Yes"
 
-    click_on "Continue"
+    proceed_with "Continue"
 
     expect(page).to have_text "Sign your change report"
     fill_in "Type your full legal name", with: "Person McPeoples"
-    click_on "Sign and submit"
+    proceed_with "Sign and submit"
 
     expect(page).to have_text "You have successfully submitted your change report"
     choose "Good", allow_label_click: true
     fill_in "Do you have any feedback for us?", with: "My feedback"
-    click_on "Submit"
+    proceed_with "Submit"
 
     expect(page).to have_content("Thanks for your feedback")
 
@@ -101,27 +102,27 @@ RSpec.feature "Reporting a change", js: true do
 
     scenario "job termination" do
       visit "/"
-      click_on "Start my report", match: :first
+      proceed_with "Start my report", match: :first
 
       expect(page).to have_text "Welcome! Here’s how reporting a change works"
-      click_on "Start the form"
+      proceed_with "Start the form"
 
       expect(page).to have_text "do you live in Arapahoe County?"
       choose "I'm not sure"
-      click_on "Continue"
+      proceed_with "Continue"
 
       expect(page).to have_text "Where do you live?"
 
       fill_in "Street address", with: "1355 South Laredo Court"
       fill_in "City", with: "Aurora"
       fill_in "Zip code", with: "80017"
-      click_on "Continue"
+      proceed_with "Continue"
       expect(page).to have_text "Great, it looks like you live in Arapahoe County."
-      click_on "Continue"
+      proceed_with "Continue"
 
       expect(page).to have_text "What changed?"
       choose "My job ended or I stopped working"
-      click_on "Continue"
+      proceed_with "Continue"
 
       expect(page).to have_text "Tell us about yourself."
 
@@ -130,7 +131,7 @@ RSpec.feature "Reporting a change", js: true do
       select "January", from: "form[birthday_month]"
       select "1", from: "form[birthday_day]"
       select 20.years.ago.year.to_s, from: "form[birthday_year]"
-      click_on "Continue"
+      proceed_with "Continue"
 
       expect(page).to have_text "Tell us about the job that ended"
     end

--- a/spec/support/feature_helper.rb
+++ b/spec/support/feature_helper.rb
@@ -1,0 +1,19 @@
+module FeatureHelper
+  def proceed_with(submit_button_text, scroll_to_top: false, **opts)
+    unless ENV["SKIP_ACCESSIBILITY_SPECS"] == "true"
+      check_accessibility(scroll_to_top)
+    end
+
+    click_on submit_button_text, opts
+  end
+
+  private
+
+  def check_accessibility(scroll_to_top)
+    expect(page).to be_accessible
+
+    if scroll_to_top
+      page.execute_script "window.scrollTo(0,0)"
+    end
+  end
+end


### PR DESCRIPTION
Runs accessibility checks on existing full-flow feature specs. Also includes fixes to make accessibility checks pass.

Can be skipped by setting SKIP_ACCESSIBILITY_SPECS="true".

This branch will fail until [this PR](https://github.com/codeforamerica/cfa-styleguide-gem/pull/19) gets merged into master for the styleguide and we update to latest version of the gem. [edit: updated! should be good]

[#160629497]