### PR TITLE
Adds unique page titles from controller names

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,8 +2,11 @@
 <html lang="en">
   <head>
     <%= render "analytics/ganalytics" %>
-
-    <title>ReportChangesColorado.org</title>
+    <% if content_for? :card_title %>
+      <title><%= content_for :card_title %> | ReportChangesColorado.org</title>
+    <% else %>
+      <title>ReportChangesColorado.org</title>
+    <% end %>
     <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>

--- a/spec/features/report_termination_spec.rb
+++ b/spec/features/report_termination_spec.rb
@@ -13,9 +13,11 @@ feature "Reporting a change", :a11y, :js do
   scenario "job termination" do
     visit "/"
     expect(page).to have_text "Report the change"
+    expect(page).to have_title "ReportChangesColorado.org"
     proceed_with "Start my report", match: :first
 
     expect(page).to have_text "Welcome! Here’s how reporting a change works"
+    expect(page).to have_title "Welcome! Here’s how reporting a change works: | ReportChangesColorado.org"
     proceed_with "Start the form"
 
     expect(page).to have_text "do you live in Arapahoe County?"


### PR DESCRIPTION
Uses the controller name for the page title.

![screen shot 2018-11-07 at 4 37 23 pm](https://user-images.githubusercontent.com/595778/48170252-8432b200-e2ab-11e8-87e0-bdb88d09946c.png)
![screen shot 2018-11-07 at 4 37 30 pm](https://user-images.githubusercontent.com/595778/48170255-87c63900-e2ab-11e8-8e6a-a64a1f6246d8.png)
![screen shot 2018-11-07 at 4 37 39 pm](https://user-images.githubusercontent.com/595778/48170257-8ac12980-e2ab-11e8-8ee7-25adea351e34.png)
![screen shot 2018-11-07 at 4 37 58 pm](https://user-images.githubusercontent.com/595778/48170262-8d238380-e2ab-11e8-88e3-cbced9b66271.png)

For the most part it is fine. A few of them could be better with question marks or if we used the `h1` from the page instead.

GetCalFresh also adds validation errors to their page titles.