### PR TITLE
Add casenumber placeholder

### DIFF
--- a/app/helpers/cfa_form_builder.rb
+++ b/app/helpers/cfa_form_builder.rb
@@ -268,7 +268,6 @@ class CfaFormBuilder < ActionView::Helpers::FormBuilder
     help_text: nil,
     options: {},
     classes: [],
-    placeholder: nil,
     autofocus: nil,
     hide_label: false,
     optional: false
@@ -277,7 +276,6 @@ class CfaFormBuilder < ActionView::Helpers::FormBuilder
     text_options = standard_options.merge(
       autofocus: autofocus,
       class: classes.join(" "),
-      placeholder: placeholder,
     ).merge(options).merge(error_attributes(method: method))
 
     <<~HTML.html_safe

--- a/app/views/tell_us_about_yourself/edit.html.erb
+++ b/app/views/tell_us_about_yourself/edit.html.erb
@@ -6,6 +6,7 @@
     <%= f.cfa_input_field :case_number,
                           t(self_or_other_member_translation_key(".case_number")),
                           help_text: t(self_or_other_member_translation_key(".case_number_help")),
+                          options: { placeholder: "1BXXXXX" },
                           optional: true %>
     <%= f.cfa_input_field :ssn,
                           t(self_or_other_member_translation_key(".ssn")),


### PR DESCRIPTION
Also removes unused/redundant placeholder argument to the form builder, since we can
pass placeholder as 'option'.

![screen shot 2018-11-13 at 11 00 55 am](https://user-images.githubusercontent.com/3675092/48436426-7e1d5500-e733-11e8-8a2e-1dc2a2e9b6fb.png)
