### PR TITLE
Default sort by created_at for administrate 0.11.0

### DIFF
--- a/app/controllers/admin/application_controller.rb
+++ b/app/controllers/admin/application_controller.rb
@@ -10,8 +10,10 @@ module Admin
     around_action :add_tags_to_logs
 
     def default_params
-      params[:order] ||= "created_at"
-      params[:direction] ||= "desc"
+      resource_params = params.fetch(resource_name, {})
+      order = resource_params.fetch(:order, "created_at")
+      direction = resource_params.fetch(:direction, "desc")
+      params[resource_name] = resource_params.merge(order: order, direction: direction)
     end
 
     def add_tags_to_logs


### PR DESCRIPTION
Administrate 0.11.0 now expects ordering params to be nested under the
resource name rather than at root. This commit fixes our broken default sorting!

I had to do some kinda weird things to get around params not having a deep_merge method. If we don't respect passed-in parameters, it breaks explicit sorting.

Added notes here: https://github.com/thoughtbot/administrate/issues/442