### PR TITLE
Allow blank string for phone number

### DIFF
--- a/app/forms/tell_us_about_change_in_hours_job_form.rb
+++ b/app/forms/tell_us_about_change_in_hours_job_form.rb
@@ -5,7 +5,7 @@ class TellUsAboutChangeInHoursJobForm < Form
   before_validation -> { strip_dashes(:manager_phone_number) }
 
   validates_presence_of :company_name, message: "Please add a name."
-  validates :manager_phone_number, ten_digit_phone_number: true, allow_nil: true
+  validates :manager_phone_number, ten_digit_phone_number: true, allow_blank: true
 
   def save
     change_report.update(attributes_for(:change_report))

--- a/spec/forms/tell_us_about_change_in_hours_job_form_spec.rb
+++ b/spec/forms/tell_us_about_change_in_hours_job_form_spec.rb
@@ -48,6 +48,14 @@ RSpec.describe TellUsAboutChangeInHoursJobForm do
         end
       end
 
+      context "when the manager_phone_number is an empty string" do
+        it "is valid" do
+          form = TellUsAboutChangeInHoursJobForm.new(nil, valid_params.merge(manager_phone_number: ""))
+
+          expect(form).to be_valid
+        end
+      end
+
       context "when the manager_phone_number has less than 10 digits" do
         it "is invalid" do
           invalid_params = valid_params.merge(manager_phone_number: "111-111-111")


### PR DESCRIPTION
Empty params come as blank string, so right now our optional field is
actually being required. This commit fixes that.

This also makes this flow consistent with the other change types.