### PR TITLE
Removes the NEW_JOB_FLOW_ENABLED dependent code

### DIFF
--- a/app.json
+++ b/app.json
@@ -42,10 +42,6 @@
     },
     "SENDING_EMAIL_ADDRESS": {
       "required": true
-    },
-    "NEW_JOB_FLOW_ENABLED": {
-      "required": false,
-      "value": "true"
     }
   },
   "formation": {

--- a/app/controllers/change_type_controller.rb
+++ b/app/controllers/change_type_controller.rb
@@ -1,5 +1,1 @@
-class ChangeTypeController < FormsController
-  def self.show_rule_sets(_change_report)
-    super << GateKeeper.feature_enabled?("NEW_JOB_FLOW")
-  end
-end
+class ChangeTypeController < FormsController; end

--- a/app/forms/county_location_form.rb
+++ b/app/forms/county_location_form.rb
@@ -8,8 +8,6 @@ class CountyLocationForm < Form
     unless change_report.present?
       self.change_report = ChangeReport.create
 
-      while_feature_flag_set_default_type
-
       change_report.create_navigator
       change_report.create_metadata
     end
@@ -22,14 +20,6 @@ class CountyLocationForm < Form
       HashWithIndifferentAccess.new(change_report.navigator.attributes)
     else
       {}
-    end
-  end
-
-  private
-
-  def while_feature_flag_set_default_type
-    unless GateKeeper.feature_enabled?("NEW_JOB_FLOW")
-      change_report.update(change_type: :job_termination)
     end
   end
 end

--- a/spec/controllers/change_type_controller_spec.rb
+++ b/spec/controllers/change_type_controller_spec.rb
@@ -6,36 +6,5 @@ RSpec.describe ChangeTypeController do
     change_type: "job_termination",
   }
   it_behaves_like "form controller unsuccessful update"
-
-  describe "show?" do
-    context "when NEW_JOB_FLOW_ENABLED is true" do
-      around do |example|
-        with_modified_env NEW_JOB_FLOW_ENABLED: "true" do
-          example.run
-        end
-      end
-
-      it "returns true" do
-        change_report = create(:change_report, :with_navigator)
-
-        show_form = ChangeTypeController.show?(change_report)
-        expect(show_form).to eq(true)
-      end
-    end
-
-    context "when NEW_JOB_FLOW_ENABLED is false" do
-      around do |example|
-        with_modified_env NEW_JOB_FLOW_ENABLED: "false" do
-          example.run
-        end
-      end
-
-      it "returns false" do
-        change_report = create(:change_report, :with_navigator)
-
-        show_form = ChangeTypeController.show?(change_report)
-        expect(show_form).to eq(false)
-      end
-    end
-  end
+  it_behaves_like "form controller always shows"
 end

--- a/spec/features/report_change_in_hours_spec.rb
+++ b/spec/features/report_change_in_hours_spec.rb
@@ -3,94 +3,90 @@ require "rails_helper"
 RSpec.feature "Reporting a change", :a11y, :js do
   include ActiveJob::TestHelper
 
-  context "when new job flow is enabled" do
-    around do |example|
-      ActionMailer::Base.deliveries.clear
-      perform_enqueued_jobs do
-        with_modified_env NEW_JOB_FLOW_ENABLED: "true" do
-          example.run
-        end
-      end
+  around do |example|
+    ActionMailer::Base.deliveries.clear
+    perform_enqueued_jobs do
+      example.run
     end
+  end
 
-    scenario "change in hours" do
-      visit "/"
-      proceed_with "Start my report", match: :first
+  scenario "change in hours" do
+    visit "/"
+    proceed_with "Start my report", match: :first
 
-      expect(page).to have_text "Welcome! Here’s how reporting a change works"
-      proceed_with "Start the form"
+    expect(page).to have_text "Welcome! Here’s how reporting a change works"
+    proceed_with "Start the form"
 
-      expect(page).to have_text "do you live in Arapahoe County?"
-      choose "Yes"
-      proceed_with "Continue"
+    expect(page).to have_text "do you live in Arapahoe County?"
+    choose "Yes"
+    proceed_with "Continue"
 
-      expect(page).to have_text "Who had this change?"
-      choose "Me"
-      proceed_with "Continue"
+    expect(page).to have_text "Who had this change?"
+    choose "Me"
+    proceed_with "Continue"
 
-      expect(page).to have_text "What is your name?"
-      fill_in "What is your first name?", with: "Jane"
-      fill_in "What is your last name?", with: "Doe"
-      proceed_with "Continue"
+    expect(page).to have_text "What is your name?"
+    fill_in "What is your first name?", with: "Jane"
+    fill_in "What is your last name?", with: "Doe"
+    proceed_with "Continue"
 
-      expect(page).to have_text "What changed?"
-      choose "My hours changed"
-      proceed_with "Continue"
+    expect(page).to have_text "What changed?"
+    choose "My hours changed"
+    proceed_with "Continue"
 
-      expect(page).to have_text "Tell us about yourself."
+    expect(page).to have_text "Tell us about yourself."
 
-      fill_in "What is your phone number?", with: "555-222-3333"
-      select "January", from: "form[birthday_month]"
-      select "1", from: "form[birthday_day]"
-      select 20.years.ago.year.to_s, from: "form[birthday_year]"
-      proceed_with "Continue"
+    fill_in "What is your phone number?", with: "555-222-3333"
+    select "January", from: "form[birthday_month]"
+    select "1", from: "form[birthday_day]"
+    select 20.years.ago.year.to_s, from: "form[birthday_year]"
+    proceed_with "Continue"
 
-      expect(page).to have_text "Tell us about this job."
+    expect(page).to have_text "Tell us about this job."
 
-      fill_in "What is the name of the company?", with: "Abc Corp"
-      fill_in "What is the name of someone from the company", with: "My boss"
-      fill_in "What is their phone number?", with: "999-888-7777"
-      proceed_with "Continue"
+    fill_in "What is the name of the company?", with: "Abc Corp"
+    fill_in "What is the name of someone from the company", with: "My boss"
+    fill_in "What is their phone number?", with: "999-888-7777"
+    proceed_with "Continue"
 
-      expect(page).to have_text "Tell us about your change in hours."
+    expect(page).to have_text "Tell us about your change in hours."
 
-      fill_in "Lower amount", with: "25" # How many hours a week will you work?
-      select "February", from: "form[change_date_month]"
-      select "21", from: "form[change_date_day]"
-      select "2018", from: "form[change_date_year]"
-      fill_in "What is your hourly wage?", with: "15"
-      fill_in "How often do you get paid?", with: "Every two weeks"
-      fill_in "Is there anything else we should know about your hours or wages at this job?", with: "Not really"
-      proceed_with "Continue"
+    fill_in "Lower amount", with: "25" # How many hours a week will you work?
+    select "February", from: "form[change_date_month]"
+    select "21", from: "form[change_date_day]"
+    select "2018", from: "form[change_date_year]"
+    fill_in "What is your hourly wage?", with: "15"
+    fill_in "How often do you get paid?", with: "Every two weeks"
+    fill_in "Is there anything else we should know about your hours or wages at this job?", with: "Not really"
+    proceed_with "Continue"
 
-      expect(page).to have_text "Do you have a letter or paystubs?"
-      choose "Yes"
-      proceed_with "Continue"
+    expect(page).to have_text "Do you have a letter or paystubs?"
+    choose "Yes"
+    proceed_with "Continue"
 
-      expect(page).to have_text "Add the letter or paystubs."
-      page.attach_file("form[letters][]", Rails.root.join("spec", "fixtures", "image.jpg"), make_visible: true)
-      expect(page).to have_text "image.jpg"
-      proceed_with "Continue"
+    expect(page).to have_text "Add the letter or paystubs."
+    page.attach_file("form[letters][]", Rails.root.join("spec", "fixtures", "image.jpg"), make_visible: true)
+    expect(page).to have_text "image.jpg"
+    proceed_with "Continue"
 
-      expect(page).to have_text "May we contact you via text message"
-      choose "Yes"
-      proceed_with "Continue"
+    expect(page).to have_text "May we contact you via text message"
+    choose "Yes"
+    proceed_with "Continue"
 
-      expect(page).to have_text "Sign your change report"
-      fill_in "Type your full legal name", with: "Person McPeoples"
-      proceed_with "Sign and submit"
+    expect(page).to have_text "Sign your change report"
+    fill_in "Type your full legal name", with: "Person McPeoples"
+    proceed_with "Sign and submit"
 
-      expect(page).to have_text "You have successfully submitted your change report"
-      choose "Good", allow_label_click: true
-      fill_in "Do you have any feedback for us?", with: "My feedback"
-      proceed_with "Submit"
+    expect(page).to have_text "You have successfully submitted your change report"
+    choose "Good", allow_label_click: true
+    fill_in "Do you have any feedback for us?", with: "My feedback"
+    proceed_with "Submit"
 
-      expect(page).to have_content("Thanks for your feedback")
+    expect(page).to have_content("Thanks for your feedback")
 
-      emails = ActionMailer::Base.deliveries
+    emails = ActionMailer::Base.deliveries
 
-      expect(emails.count).to eq 1
-      expect(emails.last.attachments.count).to eq 1
-    end
+    expect(emails.count).to eq 1
+    expect(emails.last.attachments.count).to eq 1
   end
 end

--- a/spec/features/report_change_offboarding_spec.rb
+++ b/spec/features/report_change_offboarding_spec.rb
@@ -13,42 +13,34 @@ RSpec.feature "Report change" do
     expect(page).to have_content("Find my county office")
   end
 
-  context "when new job flow is enabled" do
-    around do |example|
-      with_modified_env NEW_JOB_FLOW_ENABLED: "true" do
-        example.run
-      end
-    end
+  scenario "self employment not supported" do
+    visit "/"
+    click_on "Start my report", match: :first
 
-    scenario "self employment not supported" do
-      visit "/"
-      click_on "Start my report", match: :first
+    expect(page).to have_text "Welcome! Here’s how reporting a change works"
+    click_on "Start the form"
 
-      expect(page).to have_text "Welcome! Here’s how reporting a change works"
-      click_on "Start the form"
+    expect(page).to have_text "do you live in Arapahoe County?"
+    choose "Yes"
+    click_on "Continue"
 
-      expect(page).to have_text "do you live in Arapahoe County?"
-      choose "Yes"
-      click_on "Continue"
+    expect(page).to have_text "Who had this change?"
+    choose "Me"
+    click_on "Continue"
 
-      expect(page).to have_text "Who had this change?"
-      choose "Me"
-      click_on "Continue"
+    expect(page).to have_text "What is your name?"
+    fill_in "What is your first name?", with: "Person"
+    fill_in "What is your last name?", with: "McPeoples"
+    click_on "Continue"
 
-      expect(page).to have_text "What is your name?"
-      fill_in "What is your first name?", with: "Person"
-      fill_in "What is your last name?", with: "McPeoples"
-      click_on "Continue"
+    expect(page).to have_text "What changed?"
+    choose "I started a new job"
+    click_on "Continue"
 
-      expect(page).to have_text "What changed?"
-      choose "I started a new job"
-      click_on "Continue"
+    expect(page).to have_text "Are you self-employed?"
+    choose "I am self-employed"
+    click_on "Continue"
 
-      expect(page).to have_text "Are you self-employed?"
-      choose "I am self-employed"
-      click_on "Continue"
-
-      expect(current_path).to eq "/screens/not-yet-supported"
-    end
+    expect(current_path).to eq "/screens/not-yet-supported"
   end
 end

--- a/spec/features/report_new_job_spec.rb
+++ b/spec/features/report_new_job_spec.rb
@@ -3,101 +3,97 @@ require "rails_helper"
 RSpec.feature "Reporting a change", :a11y, :js do
   include ActiveJob::TestHelper
 
-  context "when new job flow is enabled" do
-    around do |example|
-      ActionMailer::Base.deliveries.clear
-      perform_enqueued_jobs do
-        with_modified_env NEW_JOB_FLOW_ENABLED: "true" do
-          example.run
-        end
-      end
+  around do |example|
+    ActionMailer::Base.deliveries.clear
+    perform_enqueued_jobs do
+      example.run
     end
+  end
 
-    scenario "new job" do
-      visit "/"
-      proceed_with "Start my report", match: :first
+  scenario "new job" do
+    visit "/"
+    proceed_with "Start my report", match: :first
 
-      expect(page).to have_text "Welcome! Here’s how reporting a change works"
-      proceed_with "Start the form"
+    expect(page).to have_text "Welcome! Here’s how reporting a change works"
+    proceed_with "Start the form"
 
-      expect(page).to have_text "do you live in Arapahoe County?"
-      choose "Yes"
-      proceed_with "Continue"
+    expect(page).to have_text "do you live in Arapahoe County?"
+    choose "Yes"
+    proceed_with "Continue"
 
-      expect(page).to have_text "Who had this change?"
-      choose "Someone in my household"
-      proceed_with "Continue"
+    expect(page).to have_text "Who had this change?"
+    choose "Someone in my household"
+    proceed_with "Continue"
 
-      expect(page).to have_text "Who are you reporting this change for?"
-      fill_in "What is their first name?", with: "Jane"
-      fill_in "What is their last name?", with: "Doe"
-      proceed_with "Continue"
+    expect(page).to have_text "Who are you reporting this change for?"
+    fill_in "What is their first name?", with: "Jane"
+    fill_in "What is their last name?", with: "Doe"
+    proceed_with "Continue"
 
-      expect(page).to have_text "What changed?"
-      choose "They started a new job"
-      proceed_with "Continue"
+    expect(page).to have_text "What changed?"
+    choose "They started a new job"
+    proceed_with "Continue"
 
-      expect(page).to have_text "Is Jane self-employed?"
-      choose "They are not self-employed"
-      proceed_with "Continue"
+    expect(page).to have_text "Is Jane self-employed?"
+    choose "They are not self-employed"
+    proceed_with "Continue"
 
-      expect(page).to have_text "Tell us about Jane."
-      fill_in "What is their phone number?", with: "555-222-3333"
-      select "January", from: "form[birthday_month]"
-      select "1", from: "form[birthday_day]"
-      select 20.years.ago.year.to_s, from: "form[birthday_year]"
-      proceed_with "Continue"
+    expect(page).to have_text "Tell us about Jane."
+    fill_in "What is their phone number?", with: "555-222-3333"
+    select "January", from: "form[birthday_month]"
+    select "1", from: "form[birthday_day]"
+    select 20.years.ago.year.to_s, from: "form[birthday_year]"
+    proceed_with "Continue"
 
-      expect(page).to have_text "Tell us about the new job."
+    expect(page).to have_text "Tell us about the new job."
 
-      fill_in "What is the name of the company?", with: "Abc Corp"
-      fill_in "What is the name of Jane's supervisor or manager?", with: "My boss"
-      fill_in "What is this person's phone number?", with: "999-888-7777"
-      proceed_with "Continue"
+    fill_in "What is the name of the company?", with: "Abc Corp"
+    fill_in "What is the name of Jane's supervisor or manager?", with: "My boss"
+    fill_in "What is this person's phone number?", with: "999-888-7777"
+    proceed_with "Continue"
 
-      expect(page).to have_text "Tell us more about the new job."
-      select "February", from: "form[first_day_month]"
-      select "2", from: "form[first_day_day]"
-      select "2018", from: "form[first_day_year]"
-      choose "Yes" # Have they been paid yet?
-      proceed_with "Continue"
+    expect(page).to have_text "Tell us more about the new job."
+    select "February", from: "form[first_day_month]"
+    select "2", from: "form[first_day_day]"
+    select "2018", from: "form[first_day_year]"
+    choose "Yes" # Have they been paid yet?
+    proceed_with "Continue"
 
-      expect(page).to have_text "Tell us about how much Jane will make at this job."
+    expect(page).to have_text "Tell us about how much Jane will make at this job."
 
-      fill_in "What is their hourly wage?", with: "15"
-      choose "Yes" # same number of hours
-      fill_in "How many hours a week will they work?", with: "25"
-      fill_in "How often do they get paid?", with: "Every two weeks"
-      select "February", from: "form[first_paycheck_month]"
-      select "21", from: "form[first_paycheck_day]"
-      select "2018", from: "form[first_paycheck_year]"
-      fill_in "Is there anything else we should know about Jane's hours or wages at this job?", with: "Not really"
-      proceed_with "Continue"
+    fill_in "What is their hourly wage?", with: "15"
+    choose "Yes" # same number of hours
+    fill_in "How many hours a week will they work?", with: "25"
+    fill_in "How often do they get paid?", with: "Every two weeks"
+    select "February", from: "form[first_paycheck_month]"
+    select "21", from: "form[first_paycheck_day]"
+    select "2018", from: "form[first_paycheck_year]"
+    fill_in "Is there anything else we should know about Jane's hours or wages at this job?", with: "Not really"
+    proceed_with "Continue"
 
-      expect(page).to have_text "Do you have a letter or paystubs?"
-      choose "Yes"
-      proceed_with "Continue"
+    expect(page).to have_text "Do you have a letter or paystubs?"
+    choose "Yes"
+    proceed_with "Continue"
 
-      expect(page).to have_text "Add the letter or paystubs."
-      page.attach_file("form[letters][]", Rails.root.join("spec", "fixtures", "image.jpg"), make_visible: true)
-      expect(page).to have_text "image.jpg"
-      proceed_with "Continue"
+    expect(page).to have_text "Add the letter or paystubs."
+    page.attach_file("form[letters][]", Rails.root.join("spec", "fixtures", "image.jpg"), make_visible: true)
+    expect(page).to have_text "image.jpg"
+    proceed_with "Continue"
 
-      expect(page).to have_text "Sign this change report"
-      fill_in "Type your full legal name", with: "Person McPeoples"
-      proceed_with "Sign and submit"
+    expect(page).to have_text "Sign this change report"
+    fill_in "Type your full legal name", with: "Person McPeoples"
+    proceed_with "Sign and submit"
 
-      expect(page).to have_text "You have successfully submitted this change report"
-      choose "Good", allow_label_click: true
-      fill_in "Do you have any feedback for us?", with: "My feedback"
-      proceed_with "Submit"
+    expect(page).to have_text "You have successfully submitted this change report"
+    choose "Good", allow_label_click: true
+    fill_in "Do you have any feedback for us?", with: "My feedback"
+    proceed_with "Submit"
 
-      expect(page).to have_content("Thanks for your feedback")
+    expect(page).to have_content("Thanks for your feedback")
 
-      emails = ActionMailer::Base.deliveries
+    emails = ActionMailer::Base.deliveries
 
-      expect(emails.count).to eq 1
-      expect(emails.last.attachments.count).to eq 1
-    end
+    expect(emails.count).to eq 1
+    expect(emails.last.attachments.count).to eq 1
   end
 end

--- a/spec/features/report_termination_spec.rb
+++ b/spec/features/report_termination_spec.rb
@@ -42,6 +42,10 @@ feature "Reporting a change", :a11y, :js do
     fill_in "What is your last name?", with: "Doe"
     proceed_with "Continue"
 
+    expect(page).to have_text "What changed?"
+    choose "My job ended or I stopped working"
+    proceed_with "Continue"
+
     expect(page).to have_text "Tell us about yourself."
     fill_in "What is your phone number?", with: "555-222-3333"
     select "January", from: "form[birthday_month]"
@@ -96,57 +100,5 @@ feature "Reporting a change", :a11y, :js do
 
     expect(emails.count).to eq 1
     expect(emails.last.attachments.count).to eq 1
-  end
-
-  context "when new job flow is enabled" do
-    around do |example|
-      with_modified_env NEW_JOB_FLOW_ENABLED: "true" do
-        example.run
-      end
-    end
-
-    scenario "job termination" do
-      visit "/"
-      proceed_with "Start my report", match: :first
-
-      expect(page).to have_text "Welcome! Here’s how reporting a change works"
-      proceed_with "Start the form"
-
-      expect(page).to have_text "do you live in Arapahoe County?"
-      choose "I'm not sure"
-      proceed_with "Continue"
-
-      expect(page).to have_text "Where do you live?"
-      fill_in "Street address", with: "1355 South Laredo Court"
-      fill_in "City", with: "Aurora"
-      fill_in "Zip code", with: "80017"
-      proceed_with "Continue"
-
-      expect(page).to have_text "Great, it looks like you live in Arapahoe County."
-      proceed_with "Continue"
-
-      expect(page).to have_text "Who had this change?"
-      choose "Me"
-      proceed_with "Continue"
-
-      expect(page).to have_text "What is your name?"
-      fill_in "What is your first name?", with: "Jane"
-      fill_in "What is your last name?", with: "Doe"
-      proceed_with "Continue"
-
-      expect(page).to have_text "What changed?"
-      choose "My job ended or I stopped working"
-      proceed_with "Continue"
-
-      expect(page).to have_text "Tell us about yourself."
-
-      fill_in "What is your phone number?", with: "555-222-3333"
-      select "January", from: "form[birthday_month]"
-      select "1", from: "form[birthday_day]"
-      select 20.years.ago.year.to_s, from: "form[birthday_year]"
-      proceed_with "Continue"
-
-      expect(page).to have_text "Tell us about the job that ended"
-    end
   end
 end

--- a/spec/forms/county_location_form_spec.rb
+++ b/spec/forms/county_location_form_spec.rb
@@ -57,21 +57,6 @@ RSpec.describe CountyLocationForm do
         expect(ChangeReport.last.metadata).to_not be_nil
       end
     end
-
-    context "when the new job feature is disabled" do
-      around do |example|
-        with_modified_env NEW_JOB_FLOW_ENABLED: "false" do
-          example.run
-        end
-      end
-
-      it "sets the change report change type to job_termination" do
-        form = CountyLocationForm.new(nil, valid_params)
-        form.save
-
-        expect(ChangeReport.last.change_type_job_termination?).to be_truthy
-      end
-    end
   end
 
   describe ".from_change_report" do


### PR DESCRIPTION
Need to remove the NEW_JOB_FLOW_ENABLED variable from Heroku settings on the various envs.