### PR TITLE
Multiple change reports 162248625

### DIFF
--- a/app/controllers/add_letter_controller.rb
+++ b/app/controllers/add_letter_controller.rb
@@ -1,5 +1,5 @@
 class AddLetterController < FormsController
   def self.show_rule_sets(change_report)
-    super << change_report.navigator.has_documents_yes?
+    super << change_report.has_documents_yes?
   end
 end

--- a/app/forms/county_location_form.rb
+++ b/app/forms/county_location_form.rb
@@ -6,10 +6,10 @@ class CountyLocationForm < Form
 
   def save
     unless change_report.present?
-      self.household_member = HouseholdMember.create
-      self.change_report = household_member.change_reports.create
+      navigator = Navigator.create
+      member = navigator.household_members.create
 
-      change_report.create_navigator
+      self.change_report = ChangeReport.create(member: member, navigator: navigator)
       change_report.create_metadata
     end
 

--- a/app/forms/county_location_form.rb
+++ b/app/forms/county_location_form.rb
@@ -6,7 +6,8 @@ class CountyLocationForm < Form
 
   def save
     unless change_report.present?
-      self.change_report = ChangeReport.create
+      self.household_member = HouseholdMember.create
+      self.change_report = household_member.change_reports.create
 
       change_report.create_navigator
       change_report.create_metadata

--- a/app/forms/do_you_have_a_letter_form.rb
+++ b/app/forms/do_you_have_a_letter_form.rb
@@ -1,13 +1,9 @@
 class DoYouHaveALetterForm < Form
-  set_attributes_for :navigator, :has_documents
+  set_attributes_for :change_report, :has_documents
 
   validates_presence_of :has_documents, message: "Please answer this question."
 
   def save
-    change_report.navigator.update(attributes_for(:navigator))
-  end
-
-  def self.existing_attributes(change_report)
-    HashWithIndifferentAccess.new(change_report.navigator.attributes)
+    change_report.update(attributes_for(:change_report))
   end
 end

--- a/app/forms/form.rb
+++ b/app/forms/form.rb
@@ -4,7 +4,7 @@ class Form
   include ActiveModel::Validations::Callbacks
 
   class_attribute :attribute_names
-  attr_accessor :change_report, :household_member
+  attr_accessor :change_report, :member, :navigator
 
   def initialize(change_report, params = {})
     @change_report = change_report

--- a/app/forms/form.rb
+++ b/app/forms/form.rb
@@ -4,7 +4,7 @@ class Form
   include ActiveModel::Validations::Callbacks
 
   class_attribute :attribute_names
-  attr_accessor :change_report
+  attr_accessor :change_report, :household_member
 
   def initialize(change_report, params = {})
     @change_report = change_report

--- a/app/models/change_report.rb
+++ b/app/models/change_report.rb
@@ -1,22 +1,16 @@
 class ChangeReport < ActiveRecord::Base
-  has_one :navigator,
-          class_name: "ChangeReportNavigator",
-          foreign_key: "change_report_id",
-          dependent: :destroy
+  belongs_to :member, class_name: "HouseholdMember", foreign_key: :household_member_id
+  belongs_to :navigator
 
   has_one :metadata,
           class_name: "ChangeReportMetadata",
           foreign_key: "change_report_id",
           dependent: :destroy
 
-  has_one :member,
-           class_name: "HouseholdMember",
-           foreign_key: "change_report_id",
-           dependent: :destroy
-
   has_many_attached :letters
 
   enum change_type: { unfilled: 0, job_termination: 1, new_job: 2, change_in_hours: 3 }, _prefix: :change_type
+  enum has_documents: { unfilled: 0, yes: 1, no: 2 }, _prefix: :has_documents
   enum paid_yet: { unfilled: 0, yes: 1, no: 2 }, _prefix: :paid_yet
   enum same_hours: { unfilled: 0, yes: 1, no: 2 }, _prefix: :same_hours
 

--- a/app/models/household_member.rb
+++ b/app/models/household_member.rb
@@ -1,5 +1,6 @@
 class HouseholdMember < ActiveRecord::Base
-  belongs_to :change_report
+  belongs_to :navigator
+  has_many :change_reports
 
   attribute :ssn
   attr_encrypted(

--- a/app/models/navigator.rb
+++ b/app/models/navigator.rb
@@ -1,9 +1,9 @@
-class ChangeReportNavigator < ActiveRecord::Base
-  belongs_to :change_report
+class Navigator < ActiveRecord::Base
+  has_many :change_reports
+  has_many :household_members
 
   enum selected_county_location: { unfilled: 0, arapahoe: 1, not_arapahoe: 2, not_sure: 3 },
        _prefix: :selected_county_location
-  enum has_documents: { unfilled: 0, yes: 1, no: 2 }, _prefix: :has_documents
   enum submitting_for: { unfilled: 0, self: 1, other_household_member: 2 }, _prefix: :submitting_for
   enum is_self_employed: { unfilled: 0, yes: 1, no: 2 }, _prefix: :is_self_employed
 

--- a/db/migrate/20181128185150_members_now_have_change_reports.rb
+++ b/db/migrate/20181128185150_members_now_have_change_reports.rb
@@ -1,0 +1,5 @@
+class MembersNowHaveChangeReports < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :change_reports, :household_member, index: true
+  end
+end

--- a/db/migrate/20181128213812_rename_change_report_navigator_to_navigator.rb
+++ b/db/migrate/20181128213812_rename_change_report_navigator_to_navigator.rb
@@ -1,0 +1,5 @@
+class RenameChangeReportNavigatorToNavigator < ActiveRecord::Migration[5.2]
+  def change
+    rename_table :change_report_navigators, :navigators
+  end
+end

--- a/db/migrate/20181128213900_move_has_documents_to_change_report.rb
+++ b/db/migrate/20181128213900_move_has_documents_to_change_report.rb
@@ -1,0 +1,5 @@
+class MoveHasDocumentsToChangeReport < ActiveRecord::Migration[5.2]
+  def change
+    add_column :change_reports, :has_documents, :integer, default: 0
+  end
+end

--- a/db/migrate/20181128214148_navigators_have_members.rb
+++ b/db/migrate/20181128214148_navigators_have_members.rb
@@ -1,0 +1,6 @@
+class NavigatorsHaveMembers < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :change_reports, :navigator, index: true
+    add_reference :household_members, :navigator, index: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_11_15_223104) do
+ActiveRecord::Schema.define(version: 2018_11_28_214148) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -75,22 +75,6 @@ ActiveRecord::Schema.define(version: 2018_11_15_223104) do
     t.index ["change_report_id"], name: "index_change_report_metadata_on_change_report_id"
   end
 
-  create_table "change_report_navigators", force: :cascade do |t|
-    t.bigint "change_report_id"
-    t.string "city"
-    t.string "county_from_address"
-    t.datetime "created_at", null: false
-    t.integer "has_documents", default: 0
-    t.integer "is_self_employed", default: 0
-    t.integer "selected_county_location", default: 0
-    t.string "source"
-    t.string "street_address"
-    t.integer "submitting_for", default: 0
-    t.datetime "updated_at", null: false
-    t.string "zip_code"
-    t.index ["change_report_id"], name: "index_change_report_navigators_on_change_report_id"
-  end
-
   create_table "change_reports", force: :cascade do |t|
     t.string "case_number"
     t.datetime "change_date"
@@ -100,7 +84,9 @@ ActiveRecord::Schema.define(version: 2018_11_15_223104) do
     t.datetime "created_at", null: false
     t.datetime "first_day"
     t.datetime "first_paycheck"
+    t.integer "has_documents", default: 0
     t.string "hourly_wage"
+    t.bigint "household_member_id"
     t.datetime "last_day"
     t.datetime "last_paycheck"
     t.decimal "last_paycheck_amount", precision: 8, scale: 2
@@ -108,6 +94,7 @@ ActiveRecord::Schema.define(version: 2018_11_15_223104) do
     t.string "manager_additional_information"
     t.string "manager_name"
     t.string "manager_phone_number"
+    t.bigint "navigator_id"
     t.text "new_job_notes"
     t.string "paid_how_often"
     t.integer "paid_yet", default: 0
@@ -118,6 +105,8 @@ ActiveRecord::Schema.define(version: 2018_11_15_223104) do
     t.datetime "submitted_at"
     t.datetime "updated_at", null: false
     t.string "upper_hours_a_week_amount"
+    t.index ["household_member_id"], name: "index_change_reports_on_household_member_id"
+    t.index ["navigator_id"], name: "index_change_reports_on_navigator_id"
   end
 
   create_table "delayed_jobs", force: :cascade do |t|
@@ -143,8 +132,26 @@ ActiveRecord::Schema.define(version: 2018_11_15_223104) do
     t.string "encrypted_ssn_iv"
     t.string "first_name"
     t.string "last_name"
+    t.bigint "navigator_id"
     t.datetime "updated_at", null: false
     t.index ["change_report_id"], name: "index_household_members_on_change_report_id"
+    t.index ["navigator_id"], name: "index_household_members_on_navigator_id"
+  end
+
+  create_table "navigators", force: :cascade do |t|
+    t.bigint "change_report_id"
+    t.string "city"
+    t.string "county_from_address"
+    t.datetime "created_at", null: false
+    t.integer "has_documents", default: 0
+    t.integer "is_self_employed", default: 0
+    t.integer "selected_county_location", default: 0
+    t.string "source"
+    t.string "street_address"
+    t.integer "submitting_for", default: 0
+    t.datetime "updated_at", null: false
+    t.string "zip_code"
+    t.index ["change_report_id"], name: "index_navigators_on_change_report_id"
   end
 
 end

--- a/lib/tasks/one_offs.rake
+++ b/lib/tasks/one_offs.rake
@@ -12,10 +12,12 @@ namespace :one_offs do
     # Copy over has_letter from navigator to change report
     ChangeReport.where(navigator_id: nil).each do |cr|
       navigator = Navigator.find_by_change_report_id cr.id
-      cr.update!(
-        navigator_id: navigator.id,
-        has_documents: navigator.has_documents
-      ) if navigator
+      if navigator
+        cr.update!(
+          navigator_id: navigator.id,
+          has_documents: navigator.has_documents,
+        )
+      end
     end
   end
 end

--- a/lib/tasks/one_offs.rake
+++ b/lib/tasks/one_offs.rake
@@ -2,5 +2,20 @@
 namespace :one_offs do
   desc "runs all one_offs, remove things from here after they are deployed"
   task run_all: :environment do
+    # Reassociate members and change reports
+    ChangeReport.where(household_member_id: nil).each do |cr|
+      member = HouseholdMember.find_by_change_report_id(cr.id)
+      cr.update!(household_member_id: member.id) if member
+    end
+
+    # Reassociate change reports to navigators
+    # Copy over has_letter from navigator to change report
+    ChangeReport.where(navigator_id: nil).each do |cr|
+      navigator = Navigator.find_by_change_report_id cr.id
+      cr.update!(
+        navigator_id: navigator.id,
+        has_documents: navigator.has_documents
+      ) if navigator
+    end
   end
 end

--- a/spec/controllers/add_letter_controller_spec.rb
+++ b/spec/controllers/add_letter_controller_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe AddLetterController do
     end
 
     context "with change report" do
-      let(:current_change_report) { create(:change_report, :with_navigator) }
+      let(:current_change_report) { create(:change_report) }
       let(:active_storage_blob) do
         ActiveStorage::Blob.create_after_upload!(
           io: File.open(Rails.root.join("spec", "fixtures", "image.jpg")),
@@ -62,7 +62,7 @@ RSpec.describe AddLetterController do
     context "when client has their letter" do
       it "returns true" do
         change_report = create(:change_report, navigator:
-          build(:change_report_navigator, has_documents: "yes"))
+          build(:navigator, has_documents: "yes"))
 
         show_form = AddLetterController.show?(change_report)
         expect(show_form).to eq(true)
@@ -72,7 +72,7 @@ RSpec.describe AddLetterController do
     context "when client does not have letter" do
       it "returns false" do
         change_report = create(:change_report, navigator:
-          build(:change_report_navigator, has_documents: "no"))
+          build(:navigator, has_documents: "no"))
 
         show_form = AddLetterController.show?(change_report)
         expect(show_form).to eq(false)

--- a/spec/controllers/add_letter_controller_spec.rb
+++ b/spec/controllers/add_letter_controller_spec.rb
@@ -61,8 +61,7 @@ RSpec.describe AddLetterController do
   describe "show?" do
     context "when client has their letter" do
       it "returns true" do
-        change_report = create(:change_report, navigator:
-          build(:navigator, has_documents: "yes"))
+        change_report = create(:change_report, has_documents: "yes")
 
         show_form = AddLetterController.show?(change_report)
         expect(show_form).to eq(true)
@@ -71,8 +70,7 @@ RSpec.describe AddLetterController do
 
     context "when client does not have letter" do
       it "returns false" do
-        change_report = create(:change_report, navigator:
-          build(:navigator, has_documents: "no"))
+        change_report = create(:change_report, has_documents: "no")
 
         show_form = AddLetterController.show?(change_report)
         expect(show_form).to eq(false)

--- a/spec/controllers/county_location_controller_spec.rb
+++ b/spec/controllers/county_location_controller_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe CountyLocationController do
 
       context "with an existing change report and navigator" do
         it "redirects to next path and updates the change report" do
-          current_change_report = create(:change_report, :with_navigator)
+          current_change_report = create(:change_report)
           session[:current_change_report_id] = current_change_report.id
 
           put :update, params: { form: valid_params }

--- a/spec/controllers/not_yet_supported_controller_spec.rb
+++ b/spec/controllers/not_yet_supported_controller_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe NotYetSupportedController do
   describe "show?" do
     context "when the client selects Arapahoe as their county" do
       it "returns false" do
-        navigator = build(:change_report_navigator, selected_county_location: :arapahoe)
+        navigator = build(:navigator, selected_county_location: :arapahoe)
         change_report = create(:change_report, navigator: navigator)
 
         show_form = NotYetSupportedController.show?(change_report)
@@ -16,7 +16,7 @@ RSpec.describe NotYetSupportedController do
 
     context "when the client's address is in Arapahoe County" do
       it "returns false" do
-        navigator = build(:change_report_navigator, county_from_address: "Arapahoe County")
+        navigator = build(:navigator, county_from_address: "Arapahoe County")
         change_report = create(:change_report, navigator: navigator)
 
         show_form = NotYetSupportedController.show?(change_report)
@@ -26,7 +26,7 @@ RSpec.describe NotYetSupportedController do
 
     context "when the client's county is not Arapahoe" do
       it "returns true" do
-        navigator = build(:change_report_navigator,
+        navigator = build(:navigator,
                           selected_county_location: :not_sure,
                           county_from_address: "Jefferson County")
         change_report = create(:change_report, navigator: navigator)
@@ -38,7 +38,7 @@ RSpec.describe NotYetSupportedController do
 
     context "when a client is self-employed" do
       it "returns true" do
-        navigator = build(:change_report_navigator, selected_county_location: :arapahoe, is_self_employed: "yes")
+        navigator = build(:navigator, selected_county_location: :arapahoe, is_self_employed: "yes")
         change_report = create(:change_report, navigator: navigator)
 
         show_form = NotYetSupportedController.show?(change_report)
@@ -49,7 +49,7 @@ RSpec.describe NotYetSupportedController do
 
     context "when a client is not self-employed" do
       it "returns false" do
-        navigator = build(:change_report_navigator, selected_county_location: :arapahoe, is_self_employed: "no")
+        navigator = build(:navigator, selected_county_location: :arapahoe, is_self_employed: "no")
         change_report = create(:change_report, navigator: navigator)
         show_form = NotYetSupportedController.show?(change_report)
 

--- a/spec/controllers/not_yet_supported_controller_spec.rb
+++ b/spec/controllers/not_yet_supported_controller_spec.rb
@@ -28,7 +28,8 @@ RSpec.describe NotYetSupportedController do
       it "returns true" do
         change_report.navigator.update(
           selected_county_location: :not_sure,
-          county_from_address: "Jefferson County")
+          county_from_address: "Jefferson County",
+        )
 
         show_form = NotYetSupportedController.show?(change_report)
         expect(show_form).to eq(true)

--- a/spec/controllers/not_yet_supported_controller_spec.rb
+++ b/spec/controllers/not_yet_supported_controller_spec.rb
@@ -3,11 +3,12 @@ require "rails_helper"
 RSpec.describe NotYetSupportedController do
   it_behaves_like "form controller base behavior"
 
+  let(:change_report) { create :change_report }
+
   describe "show?" do
     context "when the client selects Arapahoe as their county" do
       it "returns false" do
-        navigator = build(:navigator, selected_county_location: :arapahoe)
-        change_report = create(:change_report, navigator: navigator)
+        change_report.navigator.update selected_county_location: "arapahoe"
 
         show_form = NotYetSupportedController.show?(change_report)
         expect(show_form).to eq(false)
@@ -16,8 +17,7 @@ RSpec.describe NotYetSupportedController do
 
     context "when the client's address is in Arapahoe County" do
       it "returns false" do
-        navigator = build(:navigator, county_from_address: "Arapahoe County")
-        change_report = create(:change_report, navigator: navigator)
+        change_report.navigator.update county_from_address: "Arapahoe County", selected_county_location: "not_sure"
 
         show_form = NotYetSupportedController.show?(change_report)
         expect(show_form).to eq(false)
@@ -26,10 +26,9 @@ RSpec.describe NotYetSupportedController do
 
     context "when the client's county is not Arapahoe" do
       it "returns true" do
-        navigator = build(:navigator,
-                          selected_county_location: :not_sure,
-                          county_from_address: "Jefferson County")
-        change_report = create(:change_report, navigator: navigator)
+        change_report.navigator.update(
+          selected_county_location: :not_sure,
+          county_from_address: "Jefferson County")
 
         show_form = NotYetSupportedController.show?(change_report)
         expect(show_form).to eq(true)
@@ -38,8 +37,7 @@ RSpec.describe NotYetSupportedController do
 
     context "when a client is self-employed" do
       it "returns true" do
-        navigator = build(:navigator, selected_county_location: :arapahoe, is_self_employed: "yes")
-        change_report = create(:change_report, navigator: navigator)
+        change_report.navigator.update selected_county_location: :arapahoe, is_self_employed: "yes"
 
         show_form = NotYetSupportedController.show?(change_report)
 
@@ -49,8 +47,8 @@ RSpec.describe NotYetSupportedController do
 
     context "when a client is not self-employed" do
       it "returns false" do
-        navigator = build(:navigator, selected_county_location: :arapahoe, is_self_employed: "no")
-        change_report = create(:change_report, navigator: navigator)
+        change_report.navigator.update selected_county_location: :arapahoe, is_self_employed: "no"
+
         show_form = NotYetSupportedController.show?(change_report)
 
         expect(show_form).to be_falsey

--- a/spec/controllers/sign_submit_controller_spec.rb
+++ b/spec/controllers/sign_submit_controller_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe SignSubmitController do
         end
 
         it "does not enqueue a pdf mailer job" do
-          current_change_report = create(:change_report, :with_navigator)
+          current_change_report = create(:change_report)
           session[:current_change_report_id] = current_change_report.id
 
           allow(EmailChangeReportToOfficeJob).to receive(:perform_later)
@@ -45,7 +45,7 @@ RSpec.describe SignSubmitController do
       end
 
       it "enqueues a pdf mailer job" do
-        current_change_report = create(:change_report, :with_navigator)
+        current_change_report = create(:change_report)
         session[:current_change_report_id] = current_change_report.id
 
         allow(EmailChangeReportToOfficeJob).to receive(:perform_later)

--- a/spec/controllers/supported_county_controller_spec.rb
+++ b/spec/controllers/supported_county_controller_spec.rb
@@ -3,11 +3,12 @@ require "rails_helper"
 RSpec.describe SupportedCountyController do
   it_behaves_like "form controller base behavior"
 
+  let(:change_report) { create :change_report }
+
   describe "show?" do
     context "when the client selects Arapahoe as their county" do
       it "returns false" do
-        navigator = build(:navigator, selected_county_location: :arapahoe)
-        change_report = create(:change_report, navigator: navigator)
+        change_report.navigator.update selected_county_location: :arapahoe
 
         show_form = SupportedCountyController.show?(change_report)
         expect(show_form).to eq(false)
@@ -16,8 +17,7 @@ RSpec.describe SupportedCountyController do
 
     context "when the client's address is in Arapahoe County" do
       it "returns true" do
-        navigator = build(:navigator, county_from_address: "Arapahoe County")
-        change_report = create(:change_report, navigator: navigator)
+        change_report.navigator.update county_from_address: "Arapahoe County"
 
         show_form = SupportedCountyController.show?(change_report)
         expect(show_form).to eq(true)
@@ -26,10 +26,9 @@ RSpec.describe SupportedCountyController do
 
     context "when the client's county is not Arapahoe" do
       it "returns false" do
-        navigator = build(:navigator,
-                          selected_county_location: :not_sure,
-                          county_from_address: "Jefferson County")
-        change_report = create(:change_report, navigator: navigator)
+        change_report.navigator.update(
+          selected_county_location: :not_sure,
+          county_from_address: "Jefferson County")
 
         show_form = SupportedCountyController.show?(change_report)
         expect(show_form).to eq(false)

--- a/spec/controllers/supported_county_controller_spec.rb
+++ b/spec/controllers/supported_county_controller_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe SupportedCountyController do
   describe "show?" do
     context "when the client selects Arapahoe as their county" do
       it "returns false" do
-        navigator = build(:change_report_navigator, selected_county_location: :arapahoe)
+        navigator = build(:navigator, selected_county_location: :arapahoe)
         change_report = create(:change_report, navigator: navigator)
 
         show_form = SupportedCountyController.show?(change_report)
@@ -16,7 +16,7 @@ RSpec.describe SupportedCountyController do
 
     context "when the client's address is in Arapahoe County" do
       it "returns true" do
-        navigator = build(:change_report_navigator, county_from_address: "Arapahoe County")
+        navigator = build(:navigator, county_from_address: "Arapahoe County")
         change_report = create(:change_report, navigator: navigator)
 
         show_form = SupportedCountyController.show?(change_report)
@@ -26,7 +26,7 @@ RSpec.describe SupportedCountyController do
 
     context "when the client's county is not Arapahoe" do
       it "returns false" do
-        navigator = build(:change_report_navigator,
+        navigator = build(:navigator,
                           selected_county_location: :not_sure,
                           county_from_address: "Jefferson County")
         change_report = create(:change_report, navigator: navigator)

--- a/spec/controllers/supported_county_controller_spec.rb
+++ b/spec/controllers/supported_county_controller_spec.rb
@@ -28,7 +28,8 @@ RSpec.describe SupportedCountyController do
       it "returns false" do
         change_report.navigator.update(
           selected_county_location: :not_sure,
-          county_from_address: "Jefferson County")
+          county_from_address: "Jefferson County",
+        )
 
         show_form = SupportedCountyController.show?(change_report)
         expect(show_form).to eq(false)

--- a/spec/controllers/text_message_consent_controller_spec.rb
+++ b/spec/controllers/text_message_consent_controller_spec.rb
@@ -4,11 +4,12 @@ RSpec.describe TextMessageConsentController do
   it_behaves_like "form controller base behavior"
   it_behaves_like "form controller successful update", { consent_to_sms: "yes" }
 
+  let(:change_report) { create :change_report }
+
   describe "show?" do
     context "when client is submitting on behalf of someone" do
       it "returns false" do
-        navigator = build(:navigator, submitting_for: "other_household_member")
-        change_report = create(:change_report, navigator: navigator)
+        change_report.navigator.update submitting_for: "other_household_member"
 
         show_form = TextMessageConsentController.show?(change_report)
         expect(show_form).to eq(false)
@@ -17,8 +18,8 @@ RSpec.describe TextMessageConsentController do
 
     context "when client is submitting for themselves" do
       it "returns true" do
-        navigator = build(:navigator, submitting_for: "self")
-        change_report = create(:change_report, navigator: navigator)
+        change_report.navigator.update submitting_for: "self"
+
 
         show_form = TextMessageConsentController.show?(change_report)
         expect(show_form).to eq(true)

--- a/spec/controllers/text_message_consent_controller_spec.rb
+++ b/spec/controllers/text_message_consent_controller_spec.rb
@@ -20,7 +20,6 @@ RSpec.describe TextMessageConsentController do
       it "returns true" do
         change_report.navigator.update submitting_for: "self"
 
-
         show_form = TextMessageConsentController.show?(change_report)
         expect(show_form).to eq(true)
       end

--- a/spec/controllers/text_message_consent_controller_spec.rb
+++ b/spec/controllers/text_message_consent_controller_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe TextMessageConsentController do
   describe "show?" do
     context "when client is submitting on behalf of someone" do
       it "returns false" do
-        navigator = build(:change_report_navigator, submitting_for: "other_household_member")
+        navigator = build(:navigator, submitting_for: "other_household_member")
         change_report = create(:change_report, navigator: navigator)
 
         show_form = TextMessageConsentController.show?(change_report)
@@ -17,7 +17,7 @@ RSpec.describe TextMessageConsentController do
 
     context "when client is submitting for themselves" do
       it "returns true" do
-        navigator = build(:change_report_navigator, submitting_for: "self")
+        navigator = build(:navigator, submitting_for: "self")
         change_report = create(:change_report, navigator: navigator)
 
         show_form = TextMessageConsentController.show?(change_report)

--- a/spec/controllers/where_do_you_live_controller_spec.rb
+++ b/spec/controllers/where_do_you_live_controller_spec.rb
@@ -9,11 +9,12 @@ RSpec.describe WhereDoYouLiveController do
   }
   it_behaves_like "form controller unsuccessful update"
 
+  let(:change_report) { create :change_report }
+
   describe "show?" do
     context "when the client lives in Arapahoe County" do
       it "returns false" do
-        navigator = build(:navigator, selected_county_location: :arapahoe)
-        change_report = create(:change_report, navigator: navigator)
+        change_report.navigator.update selected_county_location: :arapahoe
 
         show_form = WhereDoYouLiveController.show?(change_report)
         expect(show_form).to eq(false)
@@ -22,8 +23,8 @@ RSpec.describe WhereDoYouLiveController do
 
     context "when the client does not live in Arapahoe County" do
       it "returns false" do
-        navigator = build(:navigator, selected_county_location: :not_arapahoe)
-        change_report = create(:change_report, navigator: navigator)
+        change_report.navigator.update selected_county_location: :not_arapahoe
+
 
         show_form = WhereDoYouLiveController.show?(change_report)
         expect(show_form).to eq(false)
@@ -32,8 +33,7 @@ RSpec.describe WhereDoYouLiveController do
 
     context "when the client doesn't know if they live in Arapahoe County" do
       it "returns true" do
-        navigator = build(:navigator, selected_county_location: :not_sure)
-        change_report = create(:change_report, navigator: navigator)
+        change_report.navigator.update selected_county_location: :not_sure
 
         show_form = WhereDoYouLiveController.show?(change_report)
         expect(show_form).to eq(true)

--- a/spec/controllers/where_do_you_live_controller_spec.rb
+++ b/spec/controllers/where_do_you_live_controller_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe WhereDoYouLiveController do
   describe "show?" do
     context "when the client lives in Arapahoe County" do
       it "returns false" do
-        navigator = build(:change_report_navigator, selected_county_location: :arapahoe)
+        navigator = build(:navigator, selected_county_location: :arapahoe)
         change_report = create(:change_report, navigator: navigator)
 
         show_form = WhereDoYouLiveController.show?(change_report)
@@ -22,7 +22,7 @@ RSpec.describe WhereDoYouLiveController do
 
     context "when the client does not live in Arapahoe County" do
       it "returns false" do
-        navigator = build(:change_report_navigator, selected_county_location: :not_arapahoe)
+        navigator = build(:navigator, selected_county_location: :not_arapahoe)
         change_report = create(:change_report, navigator: navigator)
 
         show_form = WhereDoYouLiveController.show?(change_report)
@@ -32,7 +32,7 @@ RSpec.describe WhereDoYouLiveController do
 
     context "when the client doesn't know if they live in Arapahoe County" do
       it "returns true" do
-        navigator = build(:change_report_navigator, selected_county_location: :not_sure)
+        navigator = build(:navigator, selected_county_location: :not_sure)
         change_report = create(:change_report, navigator: navigator)
 
         show_form = WhereDoYouLiveController.show?(change_report)

--- a/spec/controllers/where_do_you_live_controller_spec.rb
+++ b/spec/controllers/where_do_you_live_controller_spec.rb
@@ -25,7 +25,6 @@ RSpec.describe WhereDoYouLiveController do
       it "returns false" do
         change_report.navigator.update selected_county_location: :not_arapahoe
 
-
         show_form = WhereDoYouLiveController.show?(change_report)
         expect(show_form).to eq(false)
       end

--- a/spec/decorators/change_report_decorator_spec.rb
+++ b/spec/decorators/change_report_decorator_spec.rb
@@ -22,26 +22,16 @@ RSpec.describe ChangeReportDecorator do
   describe "#ssn" do
     context "when there is a member with a ssn" do
       it "formats it" do
-        change_report = build :change_report
-        create :household_member, change_report: change_report, ssn: "333224444"
-        decorator = ChangeReportDecorator.new(change_report)
+        member = create :member, :with_change_report, ssn: "333224444"
+        decorator = ChangeReportDecorator.new(member.change_reports.first)
         expect(decorator.ssn).to eq "333-22-4444"
       end
     end
 
     context "when there is not a ssn" do
       it "returns nil" do
-        change_report = build :change_report
-        create :household_member, change_report: change_report, ssn: ""
-        decorator = ChangeReportDecorator.new(change_report)
-        expect(decorator.ssn).to be_nil
-      end
-    end
-
-    context "when there is not a member" do
-      it "returns nil" do
-        change_report = create :change_report
-        decorator = ChangeReportDecorator.new(change_report)
+        member = create :member, :with_change_report, ssn: ""
+        decorator = ChangeReportDecorator.new(member.change_reports.first)
         expect(decorator.ssn).to be_nil
       end
     end
@@ -51,47 +41,26 @@ RSpec.describe ChangeReportDecorator do
     context "when there is a member with a birthday" do
       it "formats it" do
         birthday = DateTime.new(2018, 2, 3, 19, 5, 6)
-        change_report = build :change_report
-        create :household_member, change_report: change_report, birthday: birthday
-        decorator = ChangeReportDecorator.new(change_report)
+        member = create :member, :with_change_report, birthday: birthday
+        decorator = ChangeReportDecorator.new(member.change_reports.first)
         expect(decorator.birthday).to eq "02/03/18"
       end
     end
 
     context "when there is not a birthday" do
       it "returns nil" do
-        change_report = build :change_report
-        create :household_member, change_report: change_report, birthday: nil
-        decorator = ChangeReportDecorator.new(change_report)
-        expect(decorator.birthday).to be_nil
-      end
-    end
-
-    context "when there is not a member" do
-      it "returns nil" do
-        change_report = create :change_report
-        decorator = ChangeReportDecorator.new(change_report)
+        member = create :member, :with_change_report, birthday: nil
+        decorator = ChangeReportDecorator.new(member.change_reports.first)
         expect(decorator.birthday).to be_nil
       end
     end
   end
 
   describe "#client_name" do
-    context "when there is a member" do
-      it "returns client full name" do
-        change_report = build :change_report
-        create :household_member, change_report: change_report, first_name: "Jane", last_name: "Doe"
-        decorator = ChangeReportDecorator.new(change_report)
-        expect(decorator.client_name).to eq "Jane Doe"
-      end
-    end
-
-    context "when there is not a member" do
-      it "returns nil" do
-        change_report = create :change_report
-        decorator = ChangeReportDecorator.new(change_report)
-        expect(decorator.client_name).to be_nil
-      end
+    it "returns client full name" do
+      member = create :member, :with_change_report, first_name: "Jane", last_name: "Doe"
+      decorator = ChangeReportDecorator.new(member.change_reports.first)
+      expect(decorator.client_name).to eq "Jane Doe"
     end
   end
 

--- a/spec/decorators/change_report_decorator_spec.rb
+++ b/spec/decorators/change_report_decorator_spec.rb
@@ -22,16 +22,22 @@ RSpec.describe ChangeReportDecorator do
   describe "#ssn" do
     context "when there is a member with a ssn" do
       it "formats it" do
-        member = create :member, :with_change_report, ssn: "333224444"
-        decorator = ChangeReportDecorator.new(member.change_reports.first)
+        change_report = create :change_report
+        change_report.member.update ssn: "333224444"
+
+        decorator = ChangeReportDecorator.new(change_report)
+
         expect(decorator.ssn).to eq "333-22-4444"
       end
     end
 
     context "when there is not a ssn" do
       it "returns nil" do
-        member = create :member, :with_change_report, ssn: ""
-        decorator = ChangeReportDecorator.new(member.change_reports.first)
+        change_report = create :change_report
+        change_report.member.update ssn: ""
+
+        decorator = ChangeReportDecorator.new(change_report)
+
         expect(decorator.ssn).to be_nil
       end
     end
@@ -41,16 +47,22 @@ RSpec.describe ChangeReportDecorator do
     context "when there is a member with a birthday" do
       it "formats it" do
         birthday = DateTime.new(2018, 2, 3, 19, 5, 6)
-        member = create :member, :with_change_report, birthday: birthday
-        decorator = ChangeReportDecorator.new(member.change_reports.first)
+        change_report = create :change_report
+        change_report.member.update birthday: birthday
+
+        decorator = ChangeReportDecorator.new(change_report)
+
         expect(decorator.birthday).to eq "02/03/18"
       end
     end
 
     context "when there is not a birthday" do
       it "returns nil" do
-        member = create :member, :with_change_report, birthday: nil
-        decorator = ChangeReportDecorator.new(member.change_reports.first)
+        change_report = create :change_report
+        change_report.member.update birthday: nil
+
+        decorator = ChangeReportDecorator.new(change_report)
+
         expect(decorator.birthday).to be_nil
       end
     end
@@ -58,8 +70,11 @@ RSpec.describe ChangeReportDecorator do
 
   describe "#client_name" do
     it "returns client full name" do
-      member = create :member, :with_change_report, first_name: "Jane", last_name: "Doe"
-      decorator = ChangeReportDecorator.new(member.change_reports.first)
+      change_report = create :change_report
+      change_report.member.update first_name: "Jane", last_name: "Doe"
+
+      decorator = ChangeReportDecorator.new(change_report)
+
       expect(decorator.client_name).to eq "Jane Doe"
     end
   end

--- a/spec/factories/change_report.rb
+++ b/spec/factories/change_report.rb
@@ -1,6 +1,12 @@
 FactoryBot.define do
   factory :change_report do
-    member
+
+    before(:create) do |change_report, evaluator|
+      navigator = create :navigator
+      member = create :member, navigator: navigator
+      change_report.navigator = navigator
+      change_report.member = member
+    end
 
     trait :job_termination do
       change_type { "job_termination" }
@@ -36,4 +42,5 @@ FactoryBot.define do
 
     factory :change_report_with_letter, traits: %i[with_letter]
   end
+
 end

--- a/spec/factories/change_report.rb
+++ b/spec/factories/change_report.rb
@@ -1,29 +1,6 @@
 FactoryBot.define do
   factory :change_report do
-    trait :with_navigator do
-      transient do
-        source { nil }
-      end
-
-      after(:create) do |change_report, evaluator|
-        create(:change_report_navigator, change_report: change_report, source: evaluator.source)
-      end
-    end
-
-    trait :with_member do
-      transient do
-        first_name { "Quincy" }
-        last_name { "Jones" }
-      end
-
-      after(:create) do |change_report, evaluator|
-        create(:household_member,
-               birthday: 25.years.ago - 1.day,
-               first_name: evaluator.first_name,
-               last_name: evaluator.last_name,
-               change_report: change_report)
-      end
-    end
+    member
 
     trait :job_termination do
       change_type { "job_termination" }
@@ -57,6 +34,6 @@ FactoryBot.define do
       end
     end
 
-    factory :change_report_with_letter, traits: %i[with_navigator with_member with_letter]
+    factory :change_report_with_letter, traits: %i[with_letter]
   end
 end

--- a/spec/factories/change_report.rb
+++ b/spec/factories/change_report.rb
@@ -1,7 +1,6 @@
 FactoryBot.define do
   factory :change_report do
-
-    before(:create) do |change_report, evaluator|
+    before(:create) do |change_report|
       navigator = create :navigator
       member = create :member, navigator: navigator
       change_report.navigator = navigator
@@ -42,5 +41,4 @@ FactoryBot.define do
 
     factory :change_report_with_letter, traits: %i[with_letter]
   end
-
 end

--- a/spec/factories/household_member.rb
+++ b/spec/factories/household_member.rb
@@ -3,6 +3,7 @@ FactoryBot.define do
     first_name { "Frank" }
     last_name { "Sinatra" }
 
+
     trait :with_change_report do
       after(:create) do |member|
         create(:change_report, member: member)

--- a/spec/factories/household_member.rb
+++ b/spec/factories/household_member.rb
@@ -1,8 +1,12 @@
 FactoryBot.define do
-  factory :household_member do
-    change_report
-
+  factory :household_member, aliases: [:member] do
     first_name { "Frank" }
     last_name { "Sinatra" }
+
+    trait :with_change_report do
+      after(:create) do |member|
+        create(:change_report, member: member)
+      end
+    end
   end
 end

--- a/spec/factories/household_member.rb
+++ b/spec/factories/household_member.rb
@@ -1,8 +1,9 @@
 FactoryBot.define do
   factory :household_member, aliases: [:member] do
+    navigator
+
     first_name { "Frank" }
     last_name { "Sinatra" }
-
 
     trait :with_change_report do
       after(:create) do |member|

--- a/spec/factories/navigator.rb
+++ b/spec/factories/navigator.rb
@@ -1,5 +1,7 @@
 FactoryBot.define do
-  factory :change_report_navigator do
+  factory :navigator do
+    change_report
+
     source { "awesome-cbo" }
   end
 end

--- a/spec/factories/navigator.rb
+++ b/spec/factories/navigator.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :navigator do
-    change_report
-
+    selected_county_location { "arapahoe" }
+    is_self_employed { "no" }
     source { "awesome-cbo" }
   end
 end

--- a/spec/features/admin/admin_dashboard_spec.rb
+++ b/spec/features/admin/admin_dashboard_spec.rb
@@ -27,12 +27,8 @@ RSpec.feature "Admin viewing dashboard" do
 
     context "with verifications" do
       scenario "viewing the pdf" do
-        change_report = build(:change_report, :job_termination, :with_letter,
-                              navigator: build(:change_report_navigator, has_documents: "yes"))
-        create(:household_member,
-               first_name: "Todd",
-               last_name: "Chavez",
-               change_report: change_report)
+        change_report = create(:change_report, :job_termination, :with_letter,
+                              navigator: build(:navigator, has_documents: "yes"))
         change_report.letters.attach(
           io: File.open(Rails.root.join("spec", "fixtures", "document.pdf")),
           filename: "document.pdf",
@@ -53,7 +49,7 @@ RSpec.feature "Admin viewing dashboard" do
         pdf_attachment_text = pdf.pages.last.text
 
         expect(pdf_text).to have_content "Change Request Form"
-        expect(pdf_text).to have_content "Todd Chavez"
+        expect(pdf_text).to have_content "Frank Sinatra"
         expect(pdf_text).to have_content "See attached"
 
         expect(pdf_attachment_text).to have_content "This is the test pdf contents."
@@ -67,10 +63,10 @@ RSpec.feature "Admin viewing dashboard" do
     end
 
     scenario "can download a csv of all the change reports" do
-      create(:change_report, :with_member, :job_termination, signature: "st", manager_name: "Lavar Burton")
-      create(:change_report, :with_member, :new_job, signature: "julie", manager_name: "Bob Ross")
-      create(:change_report, :with_member, :change_in_hours, signature: "mike", manager_name: "Michael Scott")
-      create(:change_report, :with_member, signature: nil, manager_name: "Mr Burns")
+      create(:change_report, :job_termination, signature: "st", manager_name: "Lavar Burton")
+      create(:change_report, :new_job, signature: "julie", manager_name: "Bob Ross")
+      create(:change_report, :change_in_hours, signature: "mike", manager_name: "Michael Scott")
+      create(:change_report, signature: nil, manager_name: "Mr Burns")
 
       visit admin_root_path
 

--- a/spec/features/admin/admin_dashboard_spec.rb
+++ b/spec/features/admin/admin_dashboard_spec.rb
@@ -14,7 +14,7 @@ RSpec.feature "Admin viewing dashboard" do
     end
 
     scenario "viewing details for a change_report" do
-      change_report = create(:change_report)
+      change_report = create :change_report
 
       visit admin_root_path
 
@@ -27,8 +27,9 @@ RSpec.feature "Admin viewing dashboard" do
 
     context "with verifications" do
       scenario "viewing the pdf" do
-        change_report = create(:change_report, :job_termination, :with_letter,
-                              navigator: build(:navigator, has_documents: "yes"))
+        change_report = create(:change_report,
+                               :job_termination,
+                               has_documents: "yes")
         change_report.letters.attach(
           io: File.open(Rails.root.join("spec", "fixtures", "document.pdf")),
           filename: "document.pdf",

--- a/spec/forms/add_letter_form_spec.rb
+++ b/spec/forms/add_letter_form_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe AddLetterForm do
 
   describe ".from_change_report" do
     it "assigns values from change report" do
-      change_report = create(:change_report, :with_navigator)
+      change_report = create(:change_report)
       change_report.letters.attach(
         io: File.open(Rails.root.join("spec", "fixtures", "image.jpg")),
         filename: "image.jpg",

--- a/spec/forms/client_name_form_spec.rb
+++ b/spec/forms/client_name_form_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 RSpec.describe ClientNameForm do
+  let(:change_report) { create :change_report }
+
   describe "validations" do
     context "when all required attributes are provided" do
       it "is valid" do
@@ -49,57 +51,28 @@ RSpec.describe ClientNameForm do
       }
     end
 
-    context "when the member does not yet exist" do
-      it "creates member with given values" do
-        change_report = create(:change_report)
-        form = ClientNameForm.new(change_report, valid_params)
-        form.valid?
+    it "updates the member" do
+      change_report.member.update first_name: "Sophie"
+      form = ClientNameForm.new(change_report, valid_params)
+
+      expect do
         form.save
+      end.not_to(change { HouseholdMember.count })
 
-        change_report.reload
+      change_report.reload
 
-        expect(change_report.member.first_name).to eq "Annie"
-        expect(change_report.member.last_name).to eq "McDog"
-      end
-    end
-
-    context "when the member already exists" do
-      it "updates the member" do
-        member = create :member, first_name: "Sophie"
-        change_report = create :change_report, member: member
-        form = ClientNameForm.new(change_report, valid_params)
-
-        expect do
-          form.save
-        end.not_to(change { HouseholdMember.count })
-
-        change_report.reload
-
-        expect(change_report.member.first_name).to eq "Annie"
-      end
+      expect(change_report.member.first_name).to eq "Annie"
     end
   end
 
   describe ".from_change_report" do
-    context "when member exists" do
-      it "assigns values from change report and other objects" do
-        change_report = create(:change_report,
-                               member: build(:household_member, first_name: "Annie", last_name: "McDog"))
+    it "assigns values from change report and other objects" do
+      change_report.member.update first_name: "Annie", last_name: "McDog"
 
-        form = ClientNameForm.from_change_report(change_report)
+      form = ClientNameForm.from_change_report(change_report)
 
-        expect(form.first_name).to eq("Annie")
-        expect(form.last_name).to eq("McDog")
-      end
-    end
-
-    context "when member does not exist" do
-      it "assigns an empty hash" do
-        form = ClientNameForm.from_change_report(create(:change_report))
-
-        expect(form.first_name).to be_nil
-        expect(form.last_name).to be_nil
-      end
+      expect(form.first_name).to eq("Annie")
+      expect(form.last_name).to eq("McDog")
     end
   end
 end

--- a/spec/forms/client_name_form_spec.rb
+++ b/spec/forms/client_name_form_spec.rb
@@ -65,7 +65,8 @@ RSpec.describe ClientNameForm do
 
     context "when the member already exists" do
       it "updates the member" do
-        change_report = create(:change_report, :with_member, first_name: "Sophie")
+        member = create :member, first_name: "Sophie"
+        change_report = create :change_report, member: member
         form = ClientNameForm.new(change_report, valid_params)
 
         expect do

--- a/spec/forms/county_location_form_spec.rb
+++ b/spec/forms/county_location_form_spec.rb
@@ -29,10 +29,8 @@ RSpec.describe CountyLocationForm do
 
     context "with an existing change report" do
       it "updates the navigator" do
-        change_report = create(:change_report,
-                               navigator: build(:change_report_navigator,
-                                 selected_county_location: :not_sure))
-        form = CountyLocationForm.new(change_report, valid_params)
+        navigator = create(:navigator, selected_county_location: :not_sure)
+        form = CountyLocationForm.new(navigator.change_report, valid_params)
         form.valid?
 
         expect do
@@ -63,7 +61,7 @@ RSpec.describe CountyLocationForm do
     context "with an existing change report" do
       it "assigns values from change report" do
         change_report = create(:change_report)
-        create(:change_report_navigator,
+        create(:navigator,
           change_report: change_report,
           selected_county_location: "arapahoe")
 

--- a/spec/forms/county_location_form_spec.rb
+++ b/spec/forms/county_location_form_spec.rb
@@ -28,9 +28,10 @@ RSpec.describe CountyLocationForm do
     end
 
     context "with an existing change report" do
+      let(:change_report) { create :change_report }
+
       it "updates the navigator" do
-        navigator = create(:navigator, selected_county_location: :not_sure)
-        form = CountyLocationForm.new(navigator.change_report, valid_params)
+        form = CountyLocationForm.new(change_report, valid_params)
         form.valid?
 
         expect do
@@ -59,12 +60,9 @@ RSpec.describe CountyLocationForm do
 
   describe ".from_change_report" do
     context "with an existing change report" do
-      it "assigns values from change report" do
-        change_report = create(:change_report)
-        create(:navigator,
-          change_report: change_report,
-          selected_county_location: "arapahoe")
+      let(:change_report) { create :change_report }
 
+      it "assigns values from change report" do
         form = CountyLocationForm.from_change_report(change_report)
 
         expect(form.selected_county_location).to eq("arapahoe")

--- a/spec/forms/do_you_have_a_letter_form_spec.rb
+++ b/spec/forms/do_you_have_a_letter_form_spec.rb
@@ -21,7 +21,7 @@
    end
 
    describe "#save" do
-     let(:change_report) { create :change_report, :with_navigator }
+     let(:change_report) { create :change_report }
 
      let(:valid_params) do
        {
@@ -42,7 +42,7 @@
 
    describe ".from_change_report" do
      it "assigns values from change report navigator" do
-       change_report = create(:change_report, navigator: build(:change_report_navigator, has_documents: "yes"))
+       change_report = create(:change_report, navigator: build(:navigator, has_documents: "yes"))
 
        form = DoYouHaveALetterForm.from_change_report(change_report)
 

--- a/spec/forms/do_you_have_a_letter_form_spec.rb
+++ b/spec/forms/do_you_have_a_letter_form_spec.rb
@@ -36,13 +36,13 @@
 
        change_report.reload
 
-       expect(change_report.navigator.has_documents_yes?).to be_truthy
+       expect(change_report.has_documents_yes?).to be_truthy
      end
    end
 
    describe ".from_change_report" do
-     it "assigns values from change report navigator" do
-       change_report = create(:change_report, navigator: build(:navigator, has_documents: "yes"))
+     it "assigns values" do
+       change_report = create :change_report, has_documents: "yes"
 
        form = DoYouHaveALetterForm.from_change_report(change_report)
 

--- a/spec/forms/self_employed_form_spec.rb
+++ b/spec/forms/self_employed_form_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe SelfEmployedForm do
   end
 
   describe "#save" do
-    let(:change_report) { create :change_report, :with_navigator }
+    let(:change_report) { create :change_report }
 
     let(:valid_params) { { is_self_employed: "no" } }
 
@@ -44,7 +44,7 @@ RSpec.describe SelfEmployedForm do
 
   describe ".from_change_report" do
     it "assigns values from change report" do
-      navigator = build(:change_report_navigator, is_self_employed: "no")
+      navigator = build(:navigator, is_self_employed: "no")
       change_report = create(:change_report, navigator: navigator)
 
       form = SelfEmployedForm.from_change_report(change_report)

--- a/spec/forms/tell_us_about_change_in_hours_job_form_spec.rb
+++ b/spec/forms/tell_us_about_change_in_hours_job_form_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe TellUsAboutChangeInHoursJobForm do
 
   describe ".from_change_report" do
     it "assigns values from change report" do
-      change_report = create(:change_report, :with_navigator,
+      change_report = create(:change_report,
                              company_name: "Abc Corp",
                              manager_name: "Boss McBosserson",
                              manager_phone_number: "1112223333")

--- a/spec/forms/tell_us_about_the_lost_job_form_spec.rb
+++ b/spec/forms/tell_us_about_the_lost_job_form_spec.rb
@@ -84,9 +84,8 @@ RSpec.describe TellUsAboutTheLostJobForm do
   end
 
   describe ".from_change_report" do
-    it "assigns values from change report and other objects" do
+    it "assigns values from change report" do
       change_report = create(:change_report,
-        :with_navigator,
         company_name: "Abc Corp",
         manager_name: "Boss McBosser",
         manager_phone_number: "1112223333",

--- a/spec/forms/tell_us_about_the_new_job_form_spec.rb
+++ b/spec/forms/tell_us_about_the_new_job_form_spec.rb
@@ -83,9 +83,8 @@ RSpec.describe TellUsAboutTheNewJobForm do
   end
 
   describe ".from_change_report" do
-    it "assigns values from change report and other objects" do
+    it "assigns values from change report" do
       change_report = create(:change_report,
-        :with_navigator,
         company_name: "Abc Corp",
         manager_name: "Boss McBosser",
         manager_phone_number: "1112223333")

--- a/spec/forms/tell_us_about_yourself_form_spec.rb
+++ b/spec/forms/tell_us_about_yourself_form_spec.rb
@@ -145,7 +145,7 @@ RSpec.describe TellUsAboutYourselfForm do
     end
 
     it "persists the values to the correct models" do
-      change_report = create(:change_report, :with_member)
+      change_report = create(:change_report)
       form = TellUsAboutYourselfForm.new(change_report, valid_params)
       form.valid?
       form.save

--- a/spec/forms/tell_us_about_yourself_form_spec.rb
+++ b/spec/forms/tell_us_about_yourself_form_spec.rb
@@ -165,10 +165,8 @@ RSpec.describe TellUsAboutYourselfForm do
     it "assigns values from change report and other objects" do
       change_report = create(:change_report,
         case_number: "1A1234",
-        phone_number: "1234567890",
-        member: build(:household_member,
-          ssn: "111223333",
-          birthday: DateTime.new(1950, 1, 31)))
+        phone_number: "1234567890")
+      change_report.member.update ssn: "111223333", birthday: DateTime.new(1950, 1, 31)
 
       form = TellUsAboutYourselfForm.from_change_report(change_report)
 

--- a/spec/forms/tell_us_more_about_the_lost_job_form_spec.rb
+++ b/spec/forms/tell_us_more_about_the_lost_job_form_spec.rb
@@ -212,9 +212,8 @@ RSpec.describe TellUsMoreAboutTheLostJobForm do
   end
 
   describe ".from_change_report" do
-    it "assigns values from change report and other objects" do
+    it "assigns values from change report" do
       change_report = create(:change_report,
-                             :with_navigator,
                              last_day: DateTime.new(2000, 1, 15),
                              last_paycheck: DateTime.new(2018, 2, 28),
                              last_paycheck_amount: 1127.14)

--- a/spec/forms/tell_us_more_about_the_new_job_form_spec.rb
+++ b/spec/forms/tell_us_more_about_the_new_job_form_spec.rb
@@ -103,9 +103,8 @@ RSpec.describe TellUsMoreAboutTheNewJobForm do
   end
 
   describe ".from_change_report" do
-    it "assigns values from change report and other objects" do
+    it "assigns values from change report" do
       change_report = create(:change_report,
-        :with_navigator,
         first_day: DateTime.new(2000, 1, 15),
         paid_yet: "no")
 

--- a/spec/forms/where_do_you_live_form_spec.rb
+++ b/spec/forms/where_do_you_live_form_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe WhereDoYouLiveForm do
   end
 
   describe "#save" do
-    let(:change_report) { create :change_report, :with_navigator }
+    let(:change_report) { create :change_report }
     let(:valid_params) do
       {
         zip_code: "11111",
@@ -97,7 +97,7 @@ RSpec.describe WhereDoYouLiveForm do
   describe ".from_change_report" do
     it "assigns values from the change report navigator" do
       navigator = build(
-        :change_report_navigator,
+        :navigator,
         street_address: "123 Main St",
         city: "Springfield",
         zip_code: "12345",

--- a/spec/forms/where_do_you_live_form_spec.rb
+++ b/spec/forms/where_do_you_live_form_spec.rb
@@ -95,14 +95,14 @@ RSpec.describe WhereDoYouLiveForm do
   end
 
   describe ".from_change_report" do
+    let(:change_report) { create :change_report }
+
     it "assigns values from the change report navigator" do
-      navigator = build(
-        :navigator,
+      change_report.navigator.update(
         street_address: "123 Main St",
         city: "Springfield",
         zip_code: "12345",
       )
-      change_report = create(:change_report, navigator: navigator)
 
       form = WhereDoYouLiveForm.from_change_report(change_report)
 

--- a/spec/forms/who_had_change_form_spec.rb
+++ b/spec/forms/who_had_change_form_spec.rb
@@ -47,8 +47,8 @@ RSpec.describe WhoHadChangeForm do
 
   describe ".from_change_report" do
     it "assigns values from change report" do
-      navigator = build(:navigator, submitting_for: "self")
-      change_report = create(:change_report, navigator: navigator)
+      change_report = create :change_report
+      change_report.navigator.update submitting_for: "self"
 
       form = WhoHadChangeForm.from_change_report(change_report)
 

--- a/spec/forms/who_had_change_form_spec.rb
+++ b/spec/forms/who_had_change_form_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe WhoHadChangeForm do
     end
 
     it "persists the values to the correct models" do
-      change_report = create(:change_report, :with_navigator)
+      change_report = create(:change_report)
       form = WhoHadChangeForm.new(change_report, valid_params)
       form.valid?
       form.save
@@ -47,7 +47,7 @@ RSpec.describe WhoHadChangeForm do
 
   describe ".from_change_report" do
     it "assigns values from change report" do
-      navigator = build(:change_report_navigator, submitting_for: "self")
+      navigator = build(:navigator, submitting_for: "self")
       change_report = create(:change_report, navigator: navigator)
 
       form = WhoHadChangeForm.from_change_report(change_report)

--- a/spec/mailers/application_mailer_spec.rb
+++ b/spec/mailers/application_mailer_spec.rb
@@ -2,8 +2,10 @@ require "rails_helper"
 
 RSpec.describe ApplicationMailer do
   let(:change_report) do
-    create(:change_report_with_letter, :job_termination, first_name: "Joe", last_name: "MacMillan")
+    create(:change_report_with_letter, :job_termination)
   end
+
+  before { change_report.member.update first_name: "Joe", last_name: "MacMillan" }
 
   describe ".office_change_report_submission" do
     it "sets the correct headers" do

--- a/spec/models/analytics_data_spec.rb
+++ b/spec/models/analytics_data_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe AnalyticsData do
 
   describe "#to_h" do
     it "returns basic information" do
-      navigator = instance_double(ChangeReportNavigator,
+      navigator = instance_double(Navigator,
                                   county_from_address: "Littleland",
                                   has_documents: "yes",
                                   selected_county_location: "arapahoe",

--- a/spec/models/navigator_spec.rb
+++ b/spec/models/navigator_spec.rb
@@ -1,12 +1,12 @@
 require "rails_helper"
 
-RSpec.describe ChangeReportNavigator do
+RSpec.describe Navigator do
   describe ".supported_county?" do
     let(:change_report) { build(:change_report) }
 
     context "with selected county location of arapahoe" do
       it "returns true" do
-        navigator = build(:change_report_navigator,
+        navigator = build(:navigator,
                            selected_county_location: :arapahoe,
                            change_report: change_report)
 
@@ -16,7 +16,7 @@ RSpec.describe ChangeReportNavigator do
 
     context "with county from address of Arapahoe County" do
       it "returns true" do
-        navigator = build(:change_report_navigator,
+        navigator = build(:navigator,
                            county_from_address: "Arapahoe County",
                            change_report: change_report)
 
@@ -26,7 +26,7 @@ RSpec.describe ChangeReportNavigator do
 
     context "with neither selected county location nor county from address matching arapahoe" do
       it "returns false" do
-        navigator = build(:change_report_navigator,
+        navigator = build(:navigator,
                            selected_county_location: :not_sure,
                            county_from_address: "Jefferson County",
                            change_report: change_report)

--- a/spec/models/navigator_spec.rb
+++ b/spec/models/navigator_spec.rb
@@ -7,8 +7,7 @@ RSpec.describe Navigator do
     context "with selected county location of arapahoe" do
       it "returns true" do
         navigator = build(:navigator,
-                           selected_county_location: :arapahoe,
-                           change_report: change_report)
+                           selected_county_location: :arapahoe)
 
         expect(navigator.supported_county?).to be_truthy
       end
@@ -17,8 +16,7 @@ RSpec.describe Navigator do
     context "with county from address of Arapahoe County" do
       it "returns true" do
         navigator = build(:navigator,
-                           county_from_address: "Arapahoe County",
-                           change_report: change_report)
+                           county_from_address: "Arapahoe County")
 
         expect(navigator.supported_county?).to be_truthy
       end
@@ -28,8 +26,7 @@ RSpec.describe Navigator do
       it "returns false" do
         navigator = build(:navigator,
                            selected_county_location: :not_sure,
-                           county_from_address: "Jefferson County",
-                           change_report: change_report)
+                           county_from_address: "Jefferson County")
 
         expect(navigator.supported_county?).to be_falsey
       end

--- a/spec/services/change_report_pdf_builder_spec.rb
+++ b/spec/services/change_report_pdf_builder_spec.rb
@@ -3,11 +3,12 @@ require "rails_helper"
 RSpec.describe ChangeReportPdfBuilder do
   context "job termination" do
     it "creates a pdf from a Change Report" do
-      change_report = ChangeReportDecorator.new(
-        create(:change_report_with_letter, :job_termination, first_name: "Person", last_name: "McPeoples"),
-      )
+      change_report = create :change_report_with_letter, :job_termination
+      change_report.member.update first_name: "Person", last_name: "McPeoples"
 
-      raw_pdf = ChangeReportPdfBuilder.new(change_report).run
+      decorated_change_report = ChangeReportDecorator.new change_report
+
+      raw_pdf = ChangeReportPdfBuilder.new(decorated_change_report).run
       temp_file = write_raw_pdf_to_temp_file(source: raw_pdf)
       text_analysis = PDF::Inspector::Text.analyze(temp_file).strings.join.gsub("\n", " ")
 
@@ -18,11 +19,12 @@ RSpec.describe ChangeReportPdfBuilder do
 
   context "new job" do
     it "creates a pdf from a Change Report" do
-      change_report = ChangeReportDecorator.new(
-        create(:change_report_with_letter, :new_job, first_name: "Person", last_name: "McPeoples"),
-      )
+      change_report = create :change_report_with_letter, :new_job
+      change_report.member.update first_name: "Person", last_name: "McPeoples"
 
-      raw_pdf = ChangeReportPdfBuilder.new(change_report).run
+      decorated_change_report = ChangeReportDecorator.new change_report
+
+      raw_pdf = ChangeReportPdfBuilder.new(decorated_change_report).run
       temp_file = write_raw_pdf_to_temp_file(source: raw_pdf)
       text_analysis = PDF::Inspector::Text.analyze(temp_file).strings.join.gsub("\n", " ")
 

--- a/spec/services/csv_service_spec.rb
+++ b/spec/services/csv_service_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe CsvService do
     3.times do
       create :change_report
     end
-    create :change_report, :new_job, :with_member, case_number: "1a12345"
+    create :change_report, :new_job, case_number: "1a12345"
 
     change_reports = ChangeReport.all.map { |change_report| ChangeReportDecorator.new(change_report) }
     csv = CsvService.new(

--- a/spec/services/csv_service_spec.rb
+++ b/spec/services/csv_service_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe CsvService do
     expect(parsed_csv.first).to include "birthday"
     expect(parsed_csv.first).to include "change_type_description"
     expect(parsed_csv.last).to include "1a12345"
-    expect(parsed_csv.last).to include "Quincy Jones"
+    expect(parsed_csv.last).to include "Frank Sinatra"
     expect(parsed_csv.last).to include "Income change: new job"
   end
 end

--- a/spec/support/shared_examples/forms_controller_base_behavior.rb
+++ b/spec/support/shared_examples/forms_controller_base_behavior.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.shared_examples_for "form controller base behavior" do |is_last_section|
   context "with session" do
-    let(:current_change_report) { create(:change_report, :with_navigator, :with_metadata) }
+    let(:current_change_report) { create(:change_report, :with_metadata) }
 
     before do
       session[:current_change_report_id] = current_change_report.id

--- a/spec/support/shared_examples/forms_controller_successful_update.rb
+++ b/spec/support/shared_examples/forms_controller_successful_update.rb
@@ -11,7 +11,7 @@ RSpec.shared_examples_for "form controller successful update" do |valid_params|
     end
 
     context "with change report" do
-      let(:current_change_report) { create(:change_report, :with_navigator, :with_member, :with_metadata) }
+      let(:current_change_report) { create(:change_report, :with_metadata) }
 
       before do
         session[:current_change_report_id] = current_change_report.id

--- a/spec/support/shared_examples/forms_controller_unsuccessful_update.rb
+++ b/spec/support/shared_examples/forms_controller_unsuccessful_update.rb
@@ -5,7 +5,7 @@ RSpec.shared_examples_for "form controller unsuccessful update" do |invalid_para
     context "on unsucessful update" do
       let(:mock_mixpanel_service) { spy(MixpanelService) }
       let(:fake_analytics_data) { { foo: "bar" } }
-      let(:current_change_report) { create(:change_report, :with_navigator) }
+      let(:current_change_report) { create(:change_report) }
 
       before do
         session[:current_change_report_id] = current_change_report.id


### PR DESCRIPTION
Whew!

Now when a user starts a change report and gets to the page where they put in a valid county, we:
* Make a new Navigator
* Make a new House Hold Member
* Both of which are now the parents to the new Change Report
* The `has_documents` attribute now lives on the change reports.

This allows for multiple change reports.

All of the data is migrated 🥇 . All of the specs are passing 💯 .

We've already made the relevant chores for removing old columns and one_off tasks after this is merged.

The code isn't very nice yet though, here are some opportunities for improving:

Since change reports now have two parents, it makes the factories complicated. Almost all of the specs just make a change_report, which auto generates its two parents. We come in afterwards with an update to get the spec setup that we want. For example: 
```
change_report = create :change_report
change_report.member.update ssn: "333224444"
```

An alternative is to use traits to build a member with a change report. Something like: 
`create :member, :with_change_report, ssn: "333224444"`

What do you think?

Also, navigators are now the top level object. All over in the code though, we access them by using `change_report.navigator`, which could be misleading for new engineers joining the team. Any ideas for refactoring the make our new object hierarchy more apparent?