### PR TITLE
Log reports ids in admin views

### DIFF
--- a/app/controllers/admin/application_controller.rb
+++ b/app/controllers/admin/application_controller.rb
@@ -7,18 +7,12 @@
 module Admin
   class ApplicationController < Administrate::ApplicationController
     before_action :default_params
-    around_action :add_tags_to_logs
 
     def default_params
       resource_params = params.fetch(resource_name, {})
       order = resource_params.fetch(:order, "created_at")
       direction = resource_params.fetch(:direction, "desc")
       params[resource_name] = resource_params.merge(order: order, direction: direction)
-    end
-
-    def add_tags_to_logs
-      user_email = current_admin_user.email
-      Rails.logger.tagged(user_email) { yield }
     end
   end
 end

--- a/config/initializers/lograge.rb
+++ b/config/initializers/lograge.rb
@@ -3,8 +3,19 @@ Rails.application.configure do
 
   config.lograge.custom_payload do |controller|
     {
-      report_id: controller.try(:current_report).try(:id),
+      report_id: report_id(controller),
       admin_user_email: controller.try(:current_admin_user).try(:email),
     }
+  end
+
+  def report_id(controller)
+    params = controller.params
+    if params[:controller] == "admin/reports" && params[:id]
+      params[:id]
+    elsif params[:controller] ==  "admin/changes" && params[:id]
+      Change.find(params[:id]).report.id
+    else
+      controller.try(:current_report).try(:id)
+    end
   end
 end


### PR DESCRIPTION
This PR adds the report_id to log lines from relevant Admin pages.

I used the existing lograge`custom_payload` config to make it work. There is a way to pass custom data using `custom_options` in the individual controllers, yet it seems you have to do either or not both. This way was less code.

Could use a test though. Who's good at mocking logs?