### PR TITLE
Would you like a copy of this change report?

### DIFF
--- a/app/controllers/sign_submit_controller.rb
+++ b/app/controllers/sign_submit_controller.rb
@@ -8,6 +8,10 @@ class SignSubmitController < FormsController
       if current_report.metadata.consent_to_sms_yes?
         TextConfirmationToClientJob.perform_later(phone_number: current_report.phone_number)
       end
+
+      if current_report.metadata.email.present?
+        EmailReportCopyToClientJob.perform_later(report: current_report)
+      end
     end
   end
 end

--- a/app/controllers/want_a_copy_controller.rb
+++ b/app/controllers/want_a_copy_controller.rb
@@ -1,0 +1,1 @@
+class WantACopyController < FormsController; end

--- a/app/forms/form_navigation.rb
+++ b/app/forms/form_navigation.rb
@@ -34,6 +34,7 @@ class FormNavigation
     AddChangeInHoursDocumentsController,
     # Closing
     TextMessageConsentController,
+    WantACopyController,
     SignSubmitController,
     SuccessController,
   ].freeze

--- a/app/forms/want_a_copy_form.rb
+++ b/app/forms/want_a_copy_form.rb
@@ -1,0 +1,11 @@
+class WantACopyForm < Form
+  set_attributes_for :report_metadata, :email
+
+  def save
+    report.metadata.update(attributes_for(:report_metadata))
+  end
+
+  def self.existing_attributes(report)
+    HashWithIndifferentAccess.new(report.metadata.attributes)
+  end
+end

--- a/app/jobs/email_report_copy_to_client_job.rb
+++ b/app/jobs/email_report_copy_to_client_job.rb
@@ -1,0 +1,5 @@
+class EmailReportCopyToClientJob < ApplicationJob
+  def perform(report:)
+    ApplicationMailer.report_copy_to_client(report).deliver
+  end
+end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -12,6 +12,17 @@ class ApplicationMailer < ActionMailer::Base
     )
   end
 
+  def report_copy_to_client(report)
+    report = ReportDecorator.new(report)
+    attachments[attachment_name(report.client_name)] = ReportPdfBuilder.new(report).run
+
+    mail(
+      from: %("ReportChangesColorado" <#{ENV['SENDING_EMAIL_ADDRESS']}>),
+      to: report.metadata.email,
+      subject: "The requested copy of your change report.",
+    )
+  end
+
   private
 
   def attachment_name(client_name)

--- a/app/views/application_mailer/report_copy_to_client.html.erb
+++ b/app/views/application_mailer/report_copy_to_client.html.erb
@@ -1,0 +1,15 @@
+<p>
+  Hello, here is a copy of your reported change.
+</p>
+
+<p>
+  Let us know if you have any feedback about this website or ideas for how we can make reporting changes even easier. Just reply to this email.
+</p>
+
+<p>
+  Best,
+  <br>
+  Sharon Langevin, Code for America
+  <br>
+  <%= root_url %>
+</p>

--- a/app/views/want_a_copy/edit.html.erb
+++ b/app/views/want_a_copy/edit.html.erb
@@ -1,0 +1,9 @@
+<% content_for :card_title, "Would you like a copy of this change report?" %>
+
+<% content_for :card_help, "We can send you a copy for your records." %>
+
+<% content_for :card_body do %>
+  <%= fields_for(:form, @form, builder: Cfa::Styleguide::CfaFormBuilder) do |f| %>
+    <%= f.cfa_input_field :email, "What is your email address?", optional: true %>
+  <% end %>
+<% end %>

--- a/db/migrate/20190116232150_add_email_to_report_metadata.rb
+++ b/db/migrate/20190116232150_add_email_to_report_metadata.rb
@@ -1,0 +1,5 @@
+class AddEmailToReportMetadata < ActiveRecord::Migration[5.2]
+  def change
+    add_column :report_metadata, :email, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_01_15_174328) do
+ActiveRecord::Schema.define(version: 2019_01_16_232150) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -140,6 +140,7 @@ ActiveRecord::Schema.define(version: 2019_01_15_174328) do
   create_table "report_metadata", force: :cascade do |t|
     t.integer "consent_to_sms", default: 0
     t.datetime "created_at", null: false
+    t.string "email"
     t.text "feedback_comments"
     t.integer "feedback_rating", default: 0
     t.bigint "report_id"

--- a/spec/controllers/want_a_copy_controller_spec.rb
+++ b/spec/controllers/want_a_copy_controller_spec.rb
@@ -1,0 +1,9 @@
+require "rails_helper"
+
+RSpec.describe WantACopyController do
+  it_behaves_like "form controller base behavior"
+  it_behaves_like "form controller successful update", {
+    email: "email@example.com",
+  }
+  it_behaves_like "form controller always shows"
+end

--- a/spec/features/report_change_in_hours_spec.rb
+++ b/spec/features/report_change_in_hours_spec.rb
@@ -64,6 +64,10 @@ RSpec.feature "Reporting a change", :a11y, :js do
     choose "Yes"
     proceed_with "Continue"
 
+    expect(page).to have_text "Would you like a copy of this change report?"
+    fill_in "What is your email address?", with: "fake@example.com"
+    proceed_with "Continue"
+
     expect(page).to have_text "Sign your change report"
     fill_in "Type your full legal name", with: "Person McPeoples"
     proceed_with "Sign and submit"

--- a/spec/features/report_job_termination_spec.rb
+++ b/spec/features/report_job_termination_spec.rb
@@ -107,7 +107,7 @@ feature "Reporting a change", :a11y, :js do
 
     emails = ActionMailer::Base.deliveries
 
-    expect(emails.count).to eq 1
+    expect(emails.count).to eq 2
     expect(emails.last.attachments.count).to eq 1
   end
 end

--- a/spec/features/report_job_termination_spec.rb
+++ b/spec/features/report_job_termination_spec.rb
@@ -83,7 +83,10 @@ feature "Reporting a change", :a11y, :js do
     expect(page).to have_text "May we contact you via text message"
     expect(page).to have_text "We'll send text messages to (555) 222-3333"
     choose "Yes"
+    proceed_with "Continue"
 
+    expect(page).to have_text "Would you like a copy of this change report?"
+    fill_in "What is your email address?", with: "fake@example.com"
     proceed_with "Continue"
 
     expect(page).to have_text "Sign your change report"

--- a/spec/features/report_multiple_changes_spec.rb
+++ b/spec/features/report_multiple_changes_spec.rb
@@ -126,7 +126,10 @@ feature "Reporting a change", :a11y, :js do
     expect(page).to have_text "May we contact you via text message"
     expect(page).to have_text "We'll send text messages to (555) 222-3333"
     choose "Yes"
+    proceed_with "Continue"
 
+    expect(page).to have_text "Would you like a copy of this change report?"
+    fill_in "What is your email address?", with: "fake@example.com"
     proceed_with "Continue"
 
     expect(page).to have_text "Sign your change report"

--- a/spec/features/report_new_job_spec.rb
+++ b/spec/features/report_new_job_spec.rb
@@ -71,6 +71,10 @@ RSpec.feature "Reporting a change", :a11y, :js do
     expect(page).to have_text "image.jpg"
     proceed_with "Continue"
 
+    expect(page).to have_text "Would you like a copy of this change report?"
+    fill_in "What is your email address?", with: "fake@example.com"
+    proceed_with "Continue"
+
     expect(page).to have_text "Sign this change report"
     fill_in "Type your full legal name", with: "Person McPeoples"
     proceed_with "Sign and submit"

--- a/spec/forms/want_a_copy_form_spec.rb
+++ b/spec/forms/want_a_copy_form_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+RSpec.describe WantACopyForm do
+  describe "#save" do
+    let(:report) { create :report, :with_metadata }
+
+    let(:valid_params) do
+      {
+        email: "fake@example.com",
+      }
+    end
+
+    it "persists the values to the correct models" do
+      form = WantACopyForm.new(report, valid_params)
+      form.valid?
+      form.save
+
+      report.reload
+
+      expect(report.metadata.email).to eq "fake@example.com"
+    end
+  end
+
+  describe ".from_report" do
+    it "assigns values from change report" do
+      report = create(:report, metadata: build(:report_metadata, email: "fake@example.com"))
+
+      form = WantACopyForm.from_report(report)
+
+      expect(form.email).to eq "fake@example.com"
+    end
+  end
+end


### PR DESCRIPTION
If the client adds an email on this page, then when they sign and submit the document, they will receive a copy of the report emailed to them.
![screen shot 2019-01-16 at 4 03 30 pm](https://user-images.githubusercontent.com/595778/51289228-3a093380-19b4-11e9-9ae9-659686011dc1.png)

Here is the content of the email with an attached change report.
![screen shot 2019-01-16 at 5 25 53 pm](https://user-images.githubusercontent.com/595778/51289276-60c76a00-19b4-11e9-91e5-b5aac9a0d880.png)
