### PR TITLE
Report copy email changes

### DIFF
--- a/app/models/analytics_data.rb
+++ b/app/models/analytics_data.rb
@@ -59,6 +59,7 @@ class AnalyticsData
       feedback_rating: metadata.try(:feedback_rating),
       feedback_comments: metadata.try(:feedback_comments),
       what_county: metadata.try(:what_county),
+      want_a_copy: metadata.try(:email).present?,
     }
   end
 

--- a/app/views/application_mailer/report_copy_to_client.html.erb
+++ b/app/views/application_mailer/report_copy_to_client.html.erb
@@ -1,15 +1,13 @@
 <p>
-  Hello, here is a copy of your reported change.
-</p>
-
-<p>
-  Let us know if you have any feedback about this website or ideas for how we can make reporting changes even easier. Just reply to this email.
+  Hello,
+<br />
+  Here is a copy of the Change Report you submitted. Arapahoe County will use your report to see if your household benefits change. If they do, you’ll be notified. Let us know if you have any feedback about this website or ideas for how we can make reporting changes even easier. Just reply to this email.
 </p>
 
 <p>
   Best,
-  <br>
+  <br />
   Sharon Langevin, Code for America
-  <br>
+  <br />
   <%= root_url %>
 </p>

--- a/app/views/want_a_copy/edit.html.erb
+++ b/app/views/want_a_copy/edit.html.erb
@@ -4,6 +4,6 @@
 
 <% content_for :card_body do %>
   <%= fields_for(:form, @form, builder: Cfa::Styleguide::CfaFormBuilder) do |f| %>
-    <%= f.cfa_input_field :email, "What is your email address?", optional: true %>
+    <%= f.cfa_input_field :email, "What is your email address?", optional: true, type: :email %>
   <% end %>
 <% end %>

--- a/spec/models/analytics_data_spec.rb
+++ b/spec/models/analytics_data_spec.rb
@@ -17,7 +17,8 @@ RSpec.describe AnalyticsData do
                        consent_to_sms: "yes",
                        feedback_rating: "positive",
                        feedback_comments: "great!",
-                       what_county: "A different county.")
+                       what_county: "A different county.",
+                       email: nil)
 
       report = create(:report,
         created_at: DateTime.new(2018, 1, 2, 12, 0, 0),
@@ -58,6 +59,7 @@ RSpec.describe AnalyticsData do
       expect(data.fetch(:submitted_at)).to eq(DateTime.new(2018, 1, 2, 12, 10, 0))
       expect(data.fetch(:time_to_complete)).to eq(10 * 60)
       expect(data.fetch(:what_county)).to eq("A different county.")
+      expect(data.fetch(:want_a_copy)).to be_falsey
     end
 
     it "calculates time since submission" do


### PR DESCRIPTION
- Changed report copy email content
- Added type email to form field
- Tracks count of copies requested in Mixpanel via `want_a_copy: true`