### PR TITLE
Locked out after three attempts.

### DIFF
--- a/app/models/admin_user.rb
+++ b/app/models/admin_user.rb
@@ -1,4 +1,4 @@
 class AdminUser < ApplicationRecord
   devise :otp_authenticatable, :database_authenticatable,
-         :recoverable, :rememberable, :validatable, :trackable
+         :recoverable, :rememberable, :validatable, :trackable, :lockable
 end

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,0 +1,28 @@
+<h2>Log in</h2>
+
+<h1><%= flash[:alert] %></h1>
+
+<%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
+  <div class="field">
+    <%= f.label :email %><br />
+    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+  </div>
+
+  <div class="field">
+    <%= f.label :password %><br />
+    <%= f.password_field :password, autocomplete: "current-password" %>
+  </div>
+
+  <% if devise_mapping.rememberable? -%>
+    <div class="field">
+      <%= f.check_box :remember_me %>
+      <%= f.label :remember_me %>
+    </div>
+  <% end -%>
+
+  <div class="actions">
+    <%= f.submit "Log in" %>
+  </div>
+<% end %>
+
+<%= render "devise/shared/links" %>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -178,27 +178,27 @@ Devise.setup do |config|
   # Defines which strategy will be used to lock an account.
   # :failed_attempts = Locks an account after a number of failed attempts to sign in.
   # :none            = No lock strategy. You should handle locking by yourself.
-  # config.lock_strategy = :failed_attempts
+  config.lock_strategy = :failed_attempts
 
   # Defines which key will be used when locking and unlocking an account
-  # config.unlock_keys = [:email]
+  config.unlock_keys = [:email]
 
   # Defines which strategy will be used to unlock an account.
   # :email = Sends an unlock link to the user email
   # :time  = Re-enables login after a certain amount of time (see :unlock_in below)
   # :both  = Enables both strategies
   # :none  = No unlock strategy. You should handle unlocking by yourself.
-  # config.unlock_strategy = :both
+  config.unlock_strategy = :none
 
   # Number of authentication tries before locking an account if lock_strategy
   # is failed attempts.
-  # config.maximum_attempts = 20
+  config.maximum_attempts = 3
 
   # Time interval to unlock the account if :time is enabled as unlock_strategy.
   # config.unlock_in = 1.hour
 
   # Warn on the last attempt before the account is locked.
-  # config.last_attempt_warning = true
+  config.last_attempt_warning = true
 
   # ==> Configuration for :recoverable
   #

--- a/db/migrate/20190123193653_add_lockable_to_devise.rb
+++ b/db/migrate/20190123193653_add_lockable_to_devise.rb
@@ -1,0 +1,6 @@
+class AddLockableToDevise < ActiveRecord::Migration[5.2]
+  def change
+    add_column :admin_users, :failed_attempts, :integer, default: 0, null: false
+    add_column :admin_users, :locked_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_01_16_232150) do
+ActiveRecord::Schema.define(version: 2019_01_23_193653) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -42,8 +42,10 @@ ActiveRecord::Schema.define(version: 2019_01_16_232150) do
     t.inet "current_sign_in_ip"
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
+    t.integer "failed_attempts", default: 0, null: false
     t.datetime "last_sign_in_at"
     t.inet "last_sign_in_ip"
+    t.datetime "locked_at"
     t.string "otp_auth_secret"
     t.datetime "otp_challenge_expires"
     t.boolean "otp_enabled", default: false, null: false


### PR DESCRIPTION
To unlock an account - `AdminUser.first.update failed_attempts: 0, locked_at: nil`

Only warns on last wrong attempt.

Its is really easy to set up an email token where the wrong password admin user can unlock their account on there own.  https://github.com/plataformatec/devise/wiki/How-To:-Add-:lockable-to-Users. Since the only admin users are ourselves, let's leave it with out the email. If we add Colorado employee admins later, lets turn it on.

![screen shot 2019-01-23 at 12 18 04 pm](https://user-images.githubusercontent.com/595778/51634570-67e8fd80-1f09-11e9-83dc-8ddf6888763e.png)
