### PR TITLE
User accounts are set as inactive after 90 days of no activity.

### DIFF
--- a/app/models/admin_user.rb
+++ b/app/models/admin_user.rb
@@ -2,4 +2,12 @@ class AdminUser < ApplicationRecord
   devise :otp_authenticatable, :database_authenticatable,
          :recoverable, :rememberable, :validatable, :trackable,
          :timeoutable, :lockable
+
+  def active_for_authentication?
+    super && (last_sign_in_at.nil? || last_sign_in_at > 90.days.ago)
+  end
+
+  def inactive_message
+    "It's been over 90 days since you last logged in, contact an admin to regain access."
+  end
 end

--- a/spec/models/admin_user_spec.rb
+++ b/spec/models/admin_user_spec.rb
@@ -1,0 +1,26 @@
+require "rails_helper"
+
+RSpec.describe AdminUser do
+  describe "#active_for_authentication?" do
+    context "user has signed in within the last 90 days" do
+      it "returns true" do
+        user = create(:admin_user, last_sign_in_at: 1.day.ago)
+        expect(user.active_for_authentication?).to be_truthy
+      end
+    end
+
+    context "user has not signed in within the last 90 days" do
+      it "returns false" do
+        user = create(:admin_user, last_sign_in_at: 91.day.ago)
+        expect(user.active_for_authentication?).to eq(false)
+      end
+    end
+
+    context "user has never signed in before" do
+      it "returns true" do
+        user = create(:admin_user, last_sign_in_at: nil)
+        expect(user.active_for_authentication?).to be_truthy
+      end
+    end
+  end
+end


### PR DESCRIPTION
Admins can reset them by setting last_sign_in_at to nil