### PR TITLE
Document advice was broken, fixed now.

### DIFF
--- a/app/views/do_you_have_documents/edit.html.erb
+++ b/app/views/do_you_have_documents/edit.html.erb
@@ -19,14 +19,40 @@
           <%= t(self_or_other_member_translation_key(".verify_income"), name: current_report.member.first_name) %> The best ways to prove this are:
         </p>
 
-        <ul class="list--bulleted">
-          <li><%= t(self_or_other_member_translation_key(".paystubs")).html_safe %></li>
-          <li><%= t(self_or_other_member_translation_key(".change_in_hours_letter")) %></li>
-        </ul>
+        <% if current_report.current_change.change_type_job_termination? %>
+          <ul class="list--bulleted">
+            <li>A paycheck labeled “final”</li>
+            <li>A letter from your old employer</li>
+          </ul>
+          <p>It would be helpful for the letter to:</p>
+          <ul class="list--bulleted">
+            <li><%= t(self_or_other_member_translation_key(".dont_work_there"), name: current_report.member.first_name) %></li>
+            <li><%= t(self_or_other_member_translation_key(".last_day_work")) %></li>
+            <li><%= t(self_or_other_member_translation_key(".amount_last_paycheck")) %></li>
+            <li>Be on letterhead</li>
+          </ul>
+          <p>
+            If you don’t have this, we’ll work with you to find other ways to prove this change.
+          </p>
+        <% elsif current_report.current_change.change_type_new_job? %>
+          <ul class="list--bulleted">
+            <li><%= t(self_or_other_member_translation_key(".paystubs")).html_safe %></li>
+            <li><%= t(self_or_other_member_translation_key(".offer_letter")) %></li>
+          </ul>
 
-        <p>
-          If you don’t have either of these, we’ll work with you to find other ways to prove this change.
-        </p>
+          <p>
+            If you don’t have either of these, we’ll work with you to find other ways to prove this change.
+          </p>
+        <% elsif current_report.current_change.change_type_change_in_hours? %>
+          <ul class="list--bulleted">
+            <li><%= t(self_or_other_member_translation_key(".paystubs")).html_safe %></li>
+            <li><%= t(self_or_other_member_translation_key(".change_in_hours_letter")) %></li>
+          </ul>
+
+          <p>
+            If you don’t have either of these, we’ll work with you to find other ways to prove this change.
+          </p>
+        <% end %>
       </div>
     </div>
   </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -200,7 +200,7 @@ en:
       change_in_hours_notes:
         self: Is there anything else we should know about your hours or wages at this job?
         other_member: "Is there anything else we should know about %{name}'s hours or wages at this job?"
-  do_you_have_a_letter:
+  do_you_have_documents:
     edit:
       verify_income:
         self: The county needs to verify your income.


### PR DESCRIPTION
When the document page was split into different pages for different changes, the translation key needed for singular or plural wasn't also changed. Led to broken advice.

I fixed it.

![screen shot 2019-02-05 at 4 59 25 pm](https://user-images.githubusercontent.com/595778/52314460-97672380-2967-11e9-914f-45a8ab2ab16a.png)
