### PR TITLE
Migrate old data

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,7 @@ AllCops:
     - config/initializers/*
     - lib/generators/**.template
     - vendor/**/*
+    - lib/tasks/one_offs.rake
 
 Naming/AccessorMethodName:
   Description: Check the naming of accessor methods for get_/set_.

--- a/lib/tasks/one_offs.rake
+++ b/lib/tasks/one_offs.rake
@@ -8,9 +8,12 @@ namespace :one_offs do
       # get the report_id from the old changes
       r_id = change.report_id
       # All old reports only have one member
-      changes_member = Report.find(r_id).members.first
-      # give changes a member
-      change.update(member: changes_member)
+      report = Report.find_by_id(r_id)
+      if report
+        changes_member = report.members.first
+        # give changes a member
+        change.update(member: changes_member)
+      end
     end
 
     # navigator.submitting_for moved to member.is_submitter
@@ -18,14 +21,20 @@ namespace :one_offs do
       # submitting_for is an enum, is_submitter is a boolean
       is_submitter = (navigator.submitting_for == "self")
       # update old members
-      navigator.report.members.first.update(is_submitter: is_submitter)
+      member = navigator.report.members.first
+      if member
+        member.update(is_submitter: is_submitter)
+      end
     end
 
     # phone_number and case_number have moved from report to member
     Report.all.each do |report|
-      report.members.first.update(
-        phone_number: report.phone_number,
-        case_number: report.case_number)
+      member = report.members.first
+      if member
+        member.update(
+          phone_number: report.phone_number,
+          case_number: report.case_number
+        )
       end
     end
   end

--- a/lib/tasks/one_offs.rake
+++ b/lib/tasks/one_offs.rake
@@ -2,5 +2,31 @@
 namespace :one_offs do
   desc "runs all one_offs, remove things from here after they are deployed"
   task run_all: :environment do
+    # used to be report > changes
+    # now is report > member > change
+    Change.all.each do |change|
+      # get the report_id from the old changes
+      r_id = change.report_id
+      # All old reports only have one member
+      changes_member = Report.find(r_id).members.first
+      # give changes a member
+      change.update(member: changes_member)
+    end
+
+    # navigator.submitting_for moved to member.is_submitter
+    Navigator.all.each do |navigator|
+      # submitting_for is an enum, is_submitter is a boolean
+      is_submitter = (navigator.submitting_for == "self")
+      # update old members
+      navigator.report.members.first.update(is_submitter: is_submitter)
+    end
+
+    # phone_number and case_number have moved from report to member
+    Report.all.each do |report|
+      report.members.first.update(
+        phone_number: report.phone_number,
+        case_number: report.case_number)
+      end
+    end
   end
 end


### PR DESCRIPTION
- Update changes with correct members
- Update members.is_submitter from old navigators
- Move phone and case number to their members


@luigi could use another pair of eyes on this data migration. The tricky part is on production, there is no new data to worry about. On staging though, there is some newer data which we will need to guard against overwriting, just so it doesn't blow up.