### PR TITLE
Don't clear out member and change on Any Other Changes page.

### DIFF
--- a/app/controllers/any_other_changes_controller.rb
+++ b/app/controllers/any_other_changes_controller.rb
@@ -3,9 +3,6 @@ class AnyOtherChangesController < FormsController
     if form_params[:any_other_changes] == "yes"
       redirect_to change_type_screens_path
     else
-      # clear out current member and change
-      current_report.navigator.update(current_member_id: nil, current_change_id: nil)
-
       redirect_to(next_path)
     end
   end

--- a/spec/controllers/any_other_changes_controller_spec.rb
+++ b/spec/controllers/any_other_changes_controller_spec.rb
@@ -24,13 +24,6 @@ RSpec.describe AnyOtherChangesController do
       it "keep going to next page" do
         expect(response).to redirect_to(want_a_copy_screens_path)
       end
-
-      it "clears out current_member and current_change" do
-        controller.current_report.reload
-
-        expect(controller.current_report.navigator.current_member).to be_nil
-        expect(controller.current_report.navigator.current_change).to be_nil
-      end
     end
   end
 end


### PR DESCRIPTION
This PR removes some code that cleared out some data needed to navigate to the current member and current change. I've tried to find a later place to do something similar, yet we need a current report all the way to the success page for reporting feedback.

So just deleted some code.